### PR TITLE
Fix missing migration: Add m20250118_000001_create_market_tables

### DIFF
--- a/backend/migration/Cargo.lock
+++ b/backend/migration/Cargo.lock
@@ -885,7 +885,6 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 name = "migration"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "sea-orm-migration",
  "tokio",
 ]

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -1,6 +1,7 @@
 pub use sea_orm_migration::prelude::*;
 
 mod m20220101_000001_create_table;
+mod m20250118_000001_create_market_tables;
 mod m20260109_001344_add_construction_time;
 mod m20260109_002654_add_other_resources;
 mod m20260109_003719_add_construction_type;
@@ -36,6 +37,7 @@ impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
             Box::new(m20220101_000001_create_table::Migration),
+            Box::new(m20250118_000001_create_market_tables::Migration),
             Box::new(m20260109_001344_add_construction_time::Migration),
             Box::new(m20260109_002654_add_other_resources::Migration),
             Box::new(m20260109_003719_add_construction_type::Migration),

--- a/backend/migration/src/m20250118_000001_create_market_tables.rs
+++ b/backend/migration/src/m20250118_000001_create_market_tables.rs
@@ -1,0 +1,60 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create market_offers table
+        manager
+            .create_table(
+                Table::create()
+                    .table(Alias::new("market_offers"))
+                    .if_not_exists()
+                    .col(ColumnDef::new(Alias::new("id")).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Alias::new("user_id")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("planet_id")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("resource_type")).string().not_null())
+                    .col(ColumnDef::new(Alias::new("quantity")).big_integer().not_null())
+                    .col(ColumnDef::new(Alias::new("price_per_unit")).big_integer().not_null())
+                    .col(ColumnDef::new(Alias::new("offer_type")).string().not_null()) // "buy" or "sell"
+                    .col(ColumnDef::new(Alias::new("created_at")).timestamp().not_null())
+                    .col(ColumnDef::new(Alias::new("expires_at")).timestamp())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create market_transactions table
+        manager
+            .create_table(
+                Table::create()
+                    .table(Alias::new("market_transactions"))
+                    .if_not_exists()
+                    .col(ColumnDef::new(Alias::new("id")).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Alias::new("offer_id")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("buyer_id")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("seller_id")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("resource_type")).string().not_null())
+                    .col(ColumnDef::new(Alias::new("quantity")).big_integer().not_null())
+                    .col(ColumnDef::new(Alias::new("total_price")).big_integer().not_null())
+                    .col(ColumnDef::new(Alias::new("created_at")).timestamp().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Alias::new("market_transactions")).to_owned())
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(Alias::new("market_offers")).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This migration file was previously applied to the database but was missing from the codebase, causing the error:
"Migration file of version 'm20250118_000001_create_market_tables' is missing"

The migration creates two tables:
- market_offers: For tracking buy/sell offers in the marketplace
- market_transactions: For recording completed market transactions

Both tables use if_not_exists clauses to avoid conflicts with existing schema.