### PR TITLE
feat: Ajout modification du nom d'utilisateur (v1.8.0)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -47,7 +47,7 @@ use backend::AppState;
 // ✅ IMPORTS EXPLICITES
 use entities::{
     prelude::{Planet, User, CombatLog, FleetMission, TransportLog, ConstructionQueue, MarketListing, MarketTransaction, MarketPriceHistory},
-    planet, combat_log, fleet_mission, transport_log, construction_queue, market_listing, market_transaction, market_price_history
+    planet, user, combat_log, fleet_mission, transport_log, construction_queue, market_listing, market_transaction, market_price_history
 };
 
 #[derive(Serialize, Clone)]
@@ -204,6 +204,7 @@ async fn main() {
 .route("/send-message-v2", post(messaging::send_message_v2_handler))
 
 .route("/users/:id", get(get_user_handler))
+.route("/users/:id/username", patch(update_username_handler))
 .route("/players/:user_id/profile", get(get_player_profile_handler))
         // Market
         .route("/market/listings", get(get_market_listings_handler))
@@ -1744,6 +1745,62 @@ async fn get_user_handler(
     Ok(Json(response))
 }
 
+#[derive(Deserialize)]
+struct UpdateUsernamePayload {
+    new_username: String,
+}
+
+// Handler pour mettre à jour le nom d'utilisateur
+async fn update_username_handler(
+    Path(user_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Json(payload): Json<UpdateUsernamePayload>,
+) -> impl IntoResponse {
+    // Validation : username non vide et longueur raisonnable
+    let new_username = payload.new_username.trim();
+    if new_username.is_empty() || new_username.len() > 50 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Le nom d'utilisateur doit contenir entre 1 et 50 caractères"}))
+        ).into_response();
+    }
+
+    // Vérifier que l'utilisateur existe
+    let user = match User::find_by_id(user_id).one(&state.db).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "Utilisateur introuvable"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Erreur DB"}))).into_response(),
+    };
+
+    // Vérifier l'unicité du nouveau nom d'utilisateur
+    if let Ok(Some(_)) = User::find()
+        .filter(user::Column::Username.eq(new_username))
+        .filter(user::Column::Id.ne(user_id))
+        .one(&state.db)
+        .await
+    {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({"error": "Ce nom d'utilisateur est déjà utilisé"}))
+        ).into_response();
+    }
+
+    // Mettre à jour le nom d'utilisateur
+    let mut active_user: user::ActiveModel = user.into();
+    active_user.username = Set(new_username.to_string());
+
+    match active_user.update(&state.db).await {
+        Ok(updated) => Json(json!({
+            "success": true,
+            "message": "Nom d'utilisateur mis à jour",
+            "username": updated.username
+        })).into_response(),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "Erreur lors de la mise à jour"}))
+        ).into_response(),
+    }
+}
 
 // Handler pour récupérer les coûts des défenses/vaisseaux
 async fn get_unit_costs_handler() -> Result<Json<serde_json::Value>, StatusCode> {

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -20,12 +20,12 @@ interface SettingsProps {
   onVolumeChange?: (type: 'music' | 'sfx', value: number) => void;
 }
 
-export default function Settings({ 
-  planet, 
-  onUpdate, 
-  onLogout, 
-  soundEnabled, 
-  onToggleSound, 
+export default function Settings({
+  planet,
+  onUpdate,
+  onLogout,
+  soundEnabled,
+  onToggleSound,
   onStartTutorial,
   musicVolume = 0.3,
   sfxVolume = 0.5,
@@ -35,6 +35,9 @@ export default function Settings({
   const [loading, setLoading] = useState(false);
   const { theme, setTheme } = useTheme();
   const [userStats, setUserStats] = useState<any>(null);
+
+  const [newUsername, setNewUsername] = useState("");
+  const [loadingUsername, setLoadingUsername] = useState(false);
 
   const username = localStorage.getItem('username') || "Commandant";
   const userId = localStorage.getItem('user_id') || "unknown";
@@ -96,6 +99,40 @@ export default function Settings({
       toast.error("Lien neural rompu avec le serveur");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleUsernameChange = async () => {
+    if (!newUsername.trim()) {
+      toast.error("Le nom d'utilisateur ne peut pas être vide");
+      return;
+    }
+    setLoadingUsername(true);
+    try {
+      const res = await fetch(apiUrl(`/users/${userId}/username`), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ new_username: newUsername }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        localStorage.setItem('username', data.username);
+        toast.success("Identité mise à jour", { description: `Nouveau nom : ${data.username}` });
+        setNewUsername("");
+        // Recharger la page pour mettre à jour l'avatar et le nom partout
+        setTimeout(() => window.location.reload(), 1000);
+      } else {
+        const data = await res.json();
+        if (res.status === 409) {
+          toast.error("Nom déjà utilisé", { description: "Ce nom d'utilisateur est déjà pris" });
+        } else {
+          toast.error("Erreur", { description: data.error });
+        }
+      }
+    } catch (error) {
+      toast.error("Lien neural rompu avec le serveur");
+    } finally {
+      setLoadingUsername(false);
     }
   };
 
@@ -167,6 +204,46 @@ export default function Settings({
       </Card>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* --- GESTION DU COMPTE --- */}
+        <Card className="bg-slate-900/50 border-white/10 text-white backdrop-blur-md">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.2em] text-cyan-400">
+              <User size={16} /> Identité du Commandant
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-[10px] font-bold text-slate-500 uppercase ml-1">Nom d'utilisateur actuel</label>
+              <div className="p-3 bg-black/40 border border-white/10 rounded text-white font-mono text-sm">
+                {username}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-[10px] font-bold text-slate-500 uppercase ml-1">Nouveau nom d'utilisateur</label>
+              <div className="flex gap-2">
+                <Input
+                  value={newUsername}
+                  onChange={(e) => setNewUsername(e.target.value)}
+                  placeholder="Entrez un nouveau nom..."
+                  className="bg-black/40 border-white/10 text-white font-mono focus:border-cyan-500"
+                />
+                <Button
+                  onClick={handleUsernameChange}
+                  disabled={loadingUsername || !newUsername.trim()}
+                  className="bg-cyan-600 hover:bg-cyan-500 shadow-lg shadow-cyan-500/20"
+                >
+                  <Save size={16} />
+                </Button>
+              </div>
+            </div>
+            <div className="p-3 bg-cyan-500/5 rounded border border-cyan-500/20">
+              <p className="text-[10px] text-cyan-300 leading-relaxed italic">
+                "Votre identité sera mise à jour dans tous les systèmes de la galaxie. Choisissez avec soin."
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
         {/* --- CONFIGURATION PLANÈTE --- */}
         <Card className="bg-slate-900/50 border-white/10 text-white backdrop-blur-md">
           <CardHeader>
@@ -178,13 +255,13 @@ export default function Settings({
             <div className="space-y-2">
               <label className="text-[10px] font-bold text-slate-500 uppercase ml-1">Nom de la colonie</label>
               <div className="flex gap-2">
-                <Input 
-                  value={planetName} 
-                  onChange={(e) => setPlanetName(e.target.value)} 
+                <Input
+                  value={planetName}
+                  onChange={(e) => setPlanetName(e.target.value)}
                   className="bg-black/40 border-white/10 text-white font-mono focus:border-indigo-500"
                 />
-                <Button 
-                  onClick={handleRename} 
+                <Button
+                  onClick={handleRename}
                   disabled={loading || planetName === planet.name}
                   className="bg-indigo-600 hover:bg-indigo-500 shadow-lg shadow-indigo-500/20"
                 >


### PR DESCRIPTION
Backend:
- Ajout endpoint PATCH /users/:id/username
- Validation: longueur 1-50 caractères
- Vérification unicité du username
- Gestion erreurs (400, 404, 409, 500)
- Import du module user dans main.rs

Frontend:
- Nouvelle carte "Identité du Commandant" dans Settings
- Input pour nouveau nom d'utilisateur
- Validation côté client (vide)
- Toast notifications pour succès/erreurs
- Rechargement auto après modification (mise à jour avatar)
- Gestion cas 409 CONFLICT (nom déjà utilisé)

Permet aux utilisateurs de modifier leur nom d'utilisateur depuis les paramètres avec validation d'unicité.