### PR TITLE
fix: R\u00e9duction pertes exp\u00e9ditions + correction affichage Co…

### DIFF
--- a/backend/src/game_logic.rs
+++ b/backend/src/game_logic.rs
@@ -543,10 +543,10 @@ pub fn simulate_combat(fleet_size: i32, defense_bonus: i32) -> CombatResult {
     let player_strength = fleet_size + (defense_bonus * 5);
 
     if player_strength > pirate_strength {
-        // VICTOIRE : Pertes faibles (5-25% avec variation ±20%)
-        let base_loss_rate = rng.gen_range(0.05..0.25);
-        let variation = rng.gen_range(-0.2..0.2);
-        let loss_rate = (base_loss_rate * (1.0_f64 + variation)).clamp(0.01_f64, 0.4_f64);
+        // VICTOIRE : Pertes réduites (3-15% avec variation ±10%)
+        let base_loss_rate = rng.gen_range(0.03..0.15);
+        let variation = rng.gen_range(-0.1..0.1);
+        let loss_rate = (base_loss_rate * (1.0_f64 + variation)).clamp(0.01_f64, 0.20_f64);
 
         let lost = (fleet_size as f64 * loss_rate).ceil() as i32; // ceil() garantit au moins 1 si fleet > 0
         let lost = lost.max(0).min(fleet_size); // Clamp entre 0 et fleet_size
@@ -557,10 +557,10 @@ pub fn simulate_combat(fleet_size: i32, defense_bonus: i32) -> CombatResult {
             ships_lost: lost
         }
     } else {
-        // DÉFAITE : Pertes lourdes (50-90% avec variation ±20%)
-        let base_loss_rate = rng.gen_range(0.5..0.9);
-        let variation = rng.gen_range(-0.2..0.2);
-        let loss_rate = (base_loss_rate * (1.0_f64 + variation)).clamp(0.4_f64, 1.0_f64);
+        // DÉFAITE : Pertes modérées (30-60% avec variation ±15%)
+        let base_loss_rate = rng.gen_range(0.30..0.60);
+        let variation = rng.gen_range(-0.15..0.15);
+        let loss_rate = (base_loss_rate * (1.0_f64 + variation)).clamp(0.25_f64, 0.70_f64);
 
         let lost = (fleet_size as f64 * loss_rate).ceil() as i32; // ceil() garantit au moins 1
         let lost = lost.max(1).min(fleet_size); // Minimum 1 perte en cas de défaite

--- a/frontend/src/components/CombatModal.tsx
+++ b/frontend/src/components/CombatModal.tsx
@@ -137,9 +137,9 @@ export default function CombatModal({ report, onClose }: CombatModalProps) {
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/90 backdrop-blur-md p-4">
       <div className={`w-full max-w-3xl relative overflow-hidden rounded-3xl border-2 ${theme.border} bg-slate-950 shadow-[0_0_50px_rgba(0,0,0,0.5)] flex flex-col max-h-[95vh]`}>
-        
+
         {/* HEADER TACTIQUE */}
-        <div className={`p-6 border-b border-white/10 flex justify-between items-center bg-gradient-to-r ${isVictory ? 'from-green-900/40' : 'from-red-900/40'} to-transparent`}>
+        <div className={`p-6 border-b border-white/10 flex justify-between items-center bg-gradient-to-r ${isVictory ? 'from-green-900/40' : 'from-red-900/40'} to-transparent shrink-0`}>
           <div className="flex items-center gap-6">
             <div className={`p-4 rounded-2xl bg-black/60 border border-white/10 shadow-2xl ${theme.color}`}>
                 <theme.icon size={40} />
@@ -159,7 +159,10 @@ export default function CombatModal({ report, onClose }: CombatModalProps) {
           <button onClick={onClose} className="text-white/20 hover:text-white transition-colors"><X size={32} /></button>
         </div>
 
-        <div className="p-6 overflow-y-auto space-y-8 custom-scrollbar">
+        <div className="p-6 overflow-y-auto space-y-8 flex-1 min-h-0" style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: 'rgb(71 85 105) rgb(15 23 42)'
+        }}>
             
             {/* GRILLE DE RESSOURCES (BUTIN) */}
             {lootTotal > 0 && (


### PR DESCRIPTION
…mbatModal

Backend game_logic.rs:
- R\u00e9duction pertes exp\u00e9ditions (trop punitif avant)
- Victoire: 3-15% pertes (au lieu de 5-25%) avec variation ±10% (au lieu de ±20%)
- D\u00e9faite: 30-60% pertes (au lieu de 50-90%) avec variation ±15% (au lieu de ±20%)
- Exemple: 30 vaisseaux = ~1-5 pertes en victoire (au lieu de 7+)
- Rend les exp\u00e9ditions plus int\u00e9ressantes et rentables

Frontend CombatModal.tsx:
- Correction affichage rapport combat coup\u00e9/fond noir
- Ajout shrink-0 au header pour \u00e9viter qu'il se compresse
- Ajout flex-1 + min-h-0 \u00e0 la zone scrollable
- Ajout style scrollbar custom pour meilleur rendu
- Le contenu est maintenant enti\u00e8rement visible et scrollable

Impact:
- Exp\u00e9ditions moins risqu\u00e9es et plus int\u00e9ressantes
- Rapports de combat correctement affich\u00e9s