### PR TITLE
Affichage rapport et planètes

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1795,7 +1795,36 @@ async fn get_my_planets_handler(
     if let Some(p) = current {
         let my_planets = Planet::find().filter(planet::Column::OwnerId.eq(p.owner_id)).all(&state.db).await.unwrap_or_default();
         let list: Vec<serde_json::Value> = my_planets.into_iter().map(|mp| json!({
-            "id": mp.id, "name": mp.name, "galaxy": mp.galaxy, "system": mp.system, "position": mp.position, "is_current": mp.id == current_id
+            "id": mp.id,
+            "name": mp.name,
+            "galaxy": mp.galaxy,
+            "system": mp.system,
+            "position": mp.position,
+            "is_current": mp.id == current_id,
+            // Ressources
+            "metal_amount": mp.metal_amount,
+            "crystal_amount": mp.crystal_amount,
+            "deuterium_amount": mp.deuterium_amount,
+            // Bâtiments
+            "metal_mine_level": mp.metal_mine_level,
+            "crystal_mine_level": mp.crystal_mine_level,
+            "deuterium_mine_level": mp.deuterium_mine_level,
+            "solar_plant_level": mp.solar_plant_level,
+            "shipyard_level": mp.shipyard_level,
+            "research_lab_level": mp.research_lab_level,
+            "hangar_level": mp.hangar_level,
+            // Technologie
+            "energy_tech_level": mp.energy_tech_level,
+            // Flotte
+            "light_hunter_count": mp.light_hunter_count,
+            "cruiser_count": mp.cruiser_count,
+            "recycler_count": mp.recycler_count,
+            "spy_probe_count": mp.spy_probe_count,
+            "colony_ship_count": mp.colony_ship_count,
+            "transporter_count": mp.transporter_count,
+            // Défenses
+            "missile_launcher_count": mp.missile_launcher_count,
+            "plasma_turret_count": mp.plasma_turret_count
         })).collect();
         return Json(list).into_response();
     }

--- a/frontend/src/components/CombatModal.tsx
+++ b/frontend/src/components/CombatModal.tsx
@@ -207,21 +207,93 @@ export default function CombatModal({ report, onClose }: CombatModalProps) {
                 <h3 className="text-[10px] font-black text-slate-500 uppercase tracking-[0.3em] flex items-center gap-2">
                     <Activity size={12} className="text-indigo-500"/> Journal de l'IA de Combat
                 </h3>
-                <div className="bg-black border border-white/5 rounded-2xl p-3 sm:p-6 font-mono text-[10px] sm:text-[11px] leading-relaxed shadow-inner space-y-2 max-h-[200px] overflow-y-auto" style={{
+                <div className="bg-gradient-to-b from-slate-950 to-black border border-white/10 rounded-2xl p-4 sm:p-6 shadow-inner max-h-[250px] overflow-y-auto" style={{
                     scrollbarWidth: 'thin',
                     scrollbarColor: 'rgb(71 85 105) rgb(15 23 42)'
                 }}>
-                    {visibleLogs.map((log, i) => (
-                        <div key={i} className="flex gap-2 sm:gap-4 group">
-                            <span className="text-slate-700 font-bold shrink-0">[{i+1}]</span>
-                            <span className={`break-words
-                                ${log.includes("Round") ? "text-indigo-400 font-bold border-b border-indigo-500/20 w-full" : 
-                                  log.includes("VICTOIRE") ? "text-green-400 font-black" : 
-                                  log.includes("DÉFAITE") ? "text-red-400 font-black" : "text-slate-400"}
-                            `}>{log}</span>
-                        </div>
-                    ))}
-                    {visibleLogs.length === 0 && <span className="text-slate-700 italic">Initialisation des données tactiques...</span>}
+                    <div className="space-y-3">
+                        {visibleLogs.map((log, i) => {
+                            // Détection du type de log pour le style
+                            const isRadar = log.includes("RADAR") || log.includes("⚠️");
+                            const isResult = log.includes("RESULTAT") || log.includes("RÉSULTAT");
+                            const isPillage = log.includes("PILLAGE") || log.includes("DÉCOUVERTE") || log.includes("DECOUVERTE");
+                            const isPertes = log.includes("PERTES");
+                            const isScan = log.includes("SCAN");
+                            const isRound = log.includes("Round");
+                            const isVictoire = log.includes("VICTOIRE") || log.includes("Victoire");
+                            const isDefaite = log.includes("DÉFAITE") || log.includes("Défaite");
+
+                            // Nettoyer les emojis du texte pour un affichage plus propre
+                            const cleanLog = log.replace(/[⚠️🎯💀🏆]/g, '').trim();
+
+                            return (
+                                <div 
+                                    key={i} 
+                                    className={`flex items-start gap-3 p-3 rounded-xl transition-all duration-300 animate-in fade-in slide-in-from-left-2 ${
+                                        isRadar ? 'bg-yellow-500/10 border border-yellow-500/30' :
+                                        isResult && isVictoire ? 'bg-green-500/10 border border-green-500/30' :
+                                        isResult && isDefaite ? 'bg-red-500/10 border border-red-500/30' :
+                                        isResult ? 'bg-blue-500/10 border border-blue-500/30' :
+                                        isPillage ? 'bg-emerald-500/10 border border-emerald-500/30' :
+                                        isPertes ? 'bg-red-500/10 border border-red-500/30' :
+                                        isScan ? 'bg-cyan-500/10 border border-cyan-500/30' :
+                                        isRound ? 'bg-indigo-500/10 border border-indigo-500/30' :
+                                        'bg-slate-900/50 border border-white/5'
+                                    }`}
+                                    style={{ animationDelay: `${i * 50}ms` }}
+                                >
+                                    {/* Icône du type de log */}
+                                    <div className={`shrink-0 w-8 h-8 rounded-lg flex items-center justify-center ${
+                                        isRadar ? 'bg-yellow-500/20 text-yellow-400' :
+                                        isResult && isVictoire ? 'bg-green-500/20 text-green-400' :
+                                        isResult && isDefaite ? 'bg-red-500/20 text-red-400' :
+                                        isResult ? 'bg-blue-500/20 text-blue-400' :
+                                        isPillage ? 'bg-emerald-500/20 text-emerald-400' :
+                                        isPertes ? 'bg-red-500/20 text-red-400' :
+                                        isScan ? 'bg-cyan-500/20 text-cyan-400' :
+                                        isRound ? 'bg-indigo-500/20 text-indigo-400' :
+                                        'bg-slate-700/50 text-slate-500'
+                                    }`}>
+                                        {isRadar && <AlertCircle size={16} />}
+                                        {isResult && <Swords size={16} />}
+                                        {isPillage && <Box size={16} />}
+                                        {isPertes && <Skull size={16} />}
+                                        {isScan && <Activity size={16} />}
+                                        {isRound && <Zap size={16} />}
+                                        {!isRadar && !isResult && !isPillage && !isPertes && !isScan && !isRound && <Activity size={16} />}
+                                    </div>
+
+                                    {/* Contenu du log */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className={`text-xs sm:text-sm font-medium leading-relaxed ${
+                                            isRadar ? 'text-yellow-300' :
+                                            isResult && isVictoire ? 'text-green-300 font-bold' :
+                                            isResult && isDefaite ? 'text-red-300 font-bold' :
+                                            isResult ? 'text-blue-300 font-semibold' :
+                                            isPillage ? 'text-emerald-300' :
+                                            isPertes ? 'text-red-300' :
+                                            isScan ? 'text-cyan-300' :
+                                            isRound ? 'text-indigo-300 font-bold' :
+                                            'text-slate-300'
+                                        }`}>
+                                            {cleanLog}
+                                        </div>
+                                    </div>
+
+                                    {/* Numéro de séquence */}
+                                    <span className="shrink-0 text-[10px] font-mono text-slate-600 bg-slate-800/50 px-2 py-1 rounded">
+                                        #{i + 1}
+                                    </span>
+                                </div>
+                            );
+                        })}
+                        {visibleLogs.length === 0 && (
+                            <div className="flex items-center justify-center gap-3 p-6 text-slate-600">
+                                <Activity size={20} className="animate-pulse" />
+                                <span className="text-sm italic">Initialisation des données tactiques...</span>
+                            </div>
+                        )}
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/MyPlanets.tsx
+++ b/frontend/src/components/MyPlanets.tsx
@@ -52,15 +52,47 @@ export default function MyPlanets({ currentPlanetId, onSelectPlanet }: MyPlanets
     setLoading(true);
     try {
       const token = localStorage.getItem('token');
-      const res = await fetch(apiUrl('/my-planets'), {
+      const res = await fetch(apiUrl(`/my-planets?current_planet_id=${currentPlanetId}`), {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       if (res.ok) {
         const data = await res.json();
-        setPlanets(data.map((p: Planet) => ({
-          ...p,
-          is_current: p.id === currentPlanetId
-        })));
+        // Vérifier si on a reçu des données valides avec tous les champs nécessaires
+        if (Array.isArray(data) && data.length > 0 && data[0].metal_amount !== undefined) {
+          setPlanets(data.map((p: Planet) => ({
+            ...p,
+            is_current: p.id === currentPlanetId
+          })));
+        } else if (Array.isArray(data) && data.length > 0) {
+          // Le backend retourne des données partielles, on doit récupérer les détails complets
+          // Pour l'instant, on affiche ce qu'on a
+          setPlanets(data.map((p: any) => ({
+            ...p,
+            is_current: p.id === currentPlanetId,
+            // Valeurs par défaut si manquantes
+            metal_amount: p.metal_amount ?? 0,
+            crystal_amount: p.crystal_amount ?? 0,
+            deuterium_amount: p.deuterium_amount ?? 0,
+            metal_mine_level: p.metal_mine_level ?? 0,
+            crystal_mine_level: p.crystal_mine_level ?? 0,
+            deuterium_mine_level: p.deuterium_mine_level ?? 0,
+            solar_plant_level: p.solar_plant_level ?? 0,
+            shipyard_level: p.shipyard_level ?? 0,
+            research_lab_level: p.research_lab_level ?? 0,
+            hangar_level: p.hangar_level ?? 0,
+            light_hunter_count: p.light_hunter_count ?? 0,
+            cruiser_count: p.cruiser_count ?? 0,
+            recycler_count: p.recycler_count ?? 0,
+            spy_probe_count: p.spy_probe_count ?? 0,
+            colony_ship_count: p.colony_ship_count ?? 0,
+            transporter_count: p.transporter_count ?? 0,
+            missile_launcher_count: p.missile_launcher_count ?? 0,
+            plasma_turret_count: p.plasma_turret_count ?? 0,
+            energy_tech_level: p.energy_tech_level ?? 0,
+          })));
+        } else {
+          setPlanets([]);
+        }
       }
     } catch (error) {
       console.error('Erreur chargement planètes:', error);


### PR DESCRIPTION
Refactor combat log display and fix "My Planets" view to show complete planet information.

The combat log was visually unappealing, making it hard to read. The "My Planets" view was empty due to a missing `current_planet_id` parameter in the frontend request and partial data returned by the backend, preventing the display of detailed planet stats.

---
<a href="https://cursor.com/background-agent?bcId=bc-686edd4b-ff4b-45d1-bd07-72f8856a26ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-686edd4b-ff4b-45d1-bd07-72f8856a26ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

