### PR TITLE
feat(alliance): Système d'alliance complet

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -34,6 +34,7 @@ mod m20260119_000002_add_detailed_report_to_combat_log;
 mod m20260119_000003_create_server_config;
 mod m20260119_000004_create_resource_slots;
 mod m20260119_100000_add_role_to_users;
+mod m20260119_200000_create_alliance_system;
 
 pub struct Migrator;
 
@@ -75,6 +76,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260119_000003_create_server_config::Migration),
             Box::new(m20260119_000004_create_resource_slots::Migration),
             Box::new(m20260119_100000_add_role_to_users::Migration),
+            Box::new(m20260119_200000_create_alliance_system::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260119_200000_create_alliance_system.rs
+++ b/backend/migration/src/m20260119_200000_create_alliance_system.rs
@@ -1,0 +1,304 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // ═══════════════════════════════════════════════════════════════════════════
+        // TABLE: alliance
+        // ═══════════════════════════════════════════════════════════════════════════
+        manager
+            .create_table(
+                Table::create()
+                    .table(Alliance::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Alliance::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::Name)
+                            .string_len(20)
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::Tag)
+                            .string_len(5)
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Alliance::Description).text())
+                    .col(ColumnDef::new(Alliance::InternalMessage).text())
+                    .col(ColumnDef::new(Alliance::LeaderId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(Alliance::MemberCount)
+                            .integer()
+                            .not_null()
+                            .default(1),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::TotalScore)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::RecruitmentPolicy)
+                            .string_len(20)
+                            .not_null()
+                            .default("invite_only"),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::MinLevelRequired)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::CreatedAt)
+                            .timestamp()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Alliance::UpdatedAt)
+                            .timestamp()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index sur le nom et le tag pour recherche rapide
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_name")
+                    .table(Alliance::Table)
+                    .col(Alliance::Name)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_score")
+                    .table(Alliance::Table)
+                    .col(Alliance::TotalScore)
+                    .to_owned(),
+            )
+            .await?;
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // TABLE: alliance_member
+        // ═══════════════════════════════════════════════════════════════════════════
+        manager
+            .create_table(
+                Table::create()
+                    .table(AllianceMember::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AllianceMember::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::AllianceId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::UserId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::Role)
+                            .string_len(20)
+                            .not_null()
+                            .default("member"),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::Score)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::JoinedAt)
+                            .timestamp()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceMember::LastActive)
+                            .timestamp()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Contrainte unique: un utilisateur ne peut être que dans une alliance
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_member_user_unique")
+                    .table(AllianceMember::Table)
+                    .col(AllianceMember::UserId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_member_alliance")
+                    .table(AllianceMember::Table)
+                    .col(AllianceMember::AllianceId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // TABLE: alliance_invitation
+        // ═══════════════════════════════════════════════════════════════════════════
+        manager
+            .create_table(
+                Table::create()
+                    .table(AllianceInvitation::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AllianceInvitation::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceInvitation::AllianceId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceInvitation::UserId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceInvitation::InvitationType)
+                            .string_len(20)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AllianceInvitation::Status)
+                            .string_len(20)
+                            .not_null()
+                            .default("pending"),
+                    )
+                    .col(ColumnDef::new(AllianceInvitation::Message).text())
+                    .col(ColumnDef::new(AllianceInvitation::InvitedBy).uuid())
+                    .col(
+                        ColumnDef::new(AllianceInvitation::CreatedAt)
+                            .timestamp()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(AllianceInvitation::ExpiresAt).timestamp())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_invitation_user")
+                    .table(AllianceInvitation::Table)
+                    .col(AllianceInvitation::UserId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_invitation_alliance")
+                    .table(AllianceInvitation::Table)
+                    .col(AllianceInvitation::AllianceId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_alliance_invitation_status")
+                    .table(AllianceInvitation::Table)
+                    .col(AllianceInvitation::Status)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop tables in reverse order (respect foreign key constraints)
+        manager
+            .drop_table(Table::drop().table(AllianceInvitation::Table).to_owned())
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(AllianceMember::Table).to_owned())
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(Alliance::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Alliance {
+    Table,
+    Id,
+    Name,
+    Tag,
+    Description,
+    InternalMessage,
+    LeaderId,
+    MemberCount,
+    TotalScore,
+    RecruitmentPolicy,
+    MinLevelRequired,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(Iden)]
+enum AllianceMember {
+    Table,
+    Id,
+    AllianceId,
+    UserId,
+    Role,
+    Score,
+    JoinedAt,
+    LastActive,
+}
+
+#[derive(Iden)]
+enum AllianceInvitation {
+    Table,
+    Id,
+    AllianceId,
+    UserId,
+    InvitationType,
+    Status,
+    Message,
+    InvitedBy,
+    CreatedAt,
+    ExpiresAt,
+}

--- a/backend/src/alliance.rs
+++ b/backend/src/alliance.rs
@@ -1,0 +1,1295 @@
+use axum::{
+    extract::{Path, State, Query},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use sea_orm::{
+    ActiveModelTrait, EntityTrait, Set, 
+    QueryFilter, QueryOrder, ColumnTrait, Condition,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use uuid::Uuid;
+use chrono::Utc;
+
+use crate::entities::{
+    prelude::{Alliance, AllianceMember, AllianceInvitation, User, Planet},
+    alliance, alliance_member, alliance_invitation, user, planet
+};
+use crate::websocket::{WsEvent, WsState};
+use crate::AppState;
+
+// ============================================================================
+// PAYLOADS
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct CreateAlliancePayload {
+    pub name: String,
+    pub tag: String,
+    pub description: Option<String>,
+    pub recruitment_policy: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateAlliancePayload {
+    pub description: Option<String>,
+    pub internal_message: Option<String>,
+    pub recruitment_policy: Option<String>,
+    pub min_level_required: Option<i32>,
+}
+
+#[derive(Deserialize)]
+pub struct InvitePlayerPayload {
+    pub username: String,
+    pub message: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ApplicationPayload {
+    pub alliance_id: Uuid,
+    pub message: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct HandleInvitationPayload {
+    pub accept: bool,
+}
+
+#[derive(Deserialize)]
+pub struct ChangeMemberRolePayload {
+    pub role: String, // "officer" | "member"
+}
+
+// ============================================================================
+// RÉPONSES
+// ============================================================================
+
+#[derive(Serialize)]
+pub struct AllianceDisplay {
+    pub id: Uuid,
+    pub name: String,
+    pub tag: String,
+    pub description: Option<String>,
+    pub leader_name: String,
+    pub member_count: i32,
+    pub total_score: i64,
+    pub recruitment_policy: String,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Serialize)]
+pub struct AllianceDetailDisplay {
+    pub id: Uuid,
+    pub name: String,
+    pub tag: String,
+    pub description: Option<String>,
+    pub internal_message: Option<String>,
+    pub leader_id: Uuid,
+    pub leader_name: String,
+    pub member_count: i32,
+    pub total_score: i64,
+    pub recruitment_policy: String,
+    pub min_level_required: i32,
+    pub members: Vec<MemberDisplay>,
+    pub created_at: chrono::NaiveDateTime,
+    pub is_member: bool,
+    pub user_role: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct MemberDisplay {
+    pub user_id: Uuid,
+    pub username: String,
+    pub role: String,
+    pub score: i64,
+    pub joined_at: chrono::NaiveDateTime,
+    pub last_active: chrono::NaiveDateTime,
+}
+
+#[derive(Serialize)]
+pub struct InvitationDisplay {
+    pub id: Uuid,
+    pub alliance_id: Uuid,
+    pub alliance_name: String,
+    pub alliance_tag: String,
+    pub user_id: Uuid,
+    pub username: String,
+    pub invitation_type: String,
+    pub status: String,
+    pub message: Option<String>,
+    pub created_at: chrono::NaiveDateTime,
+}
+
+// ============================================================================
+// HANDLERS: CRUD ALLIANCE
+// ============================================================================
+
+/// Liste toutes les alliances (avec pagination/recherche)
+pub async fn list_alliances_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let search = params.get("search").cloned();
+    let page: u64 = params.get("page").and_then(|p| p.parse().ok()).unwrap_or(1);
+    let per_page: u64 = params.get("per_page").and_then(|p| p.parse().ok()).unwrap_or(20);
+
+    let mut query = Alliance::find().order_by_desc(alliance::Column::TotalScore);
+
+    if let Some(search_term) = search {
+        query = query.filter(
+            Condition::any()
+                .add(alliance::Column::Name.contains(&search_term))
+                .add(alliance::Column::Tag.contains(&search_term))
+        );
+    }
+
+    let alliances = query
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    // Paginer manuellement
+    let total = alliances.len();
+    let start = ((page - 1) * per_page) as usize;
+    let end = (start + per_page as usize).min(total);
+    let page_alliances = if start < total { &alliances[start..end] } else { &[] };
+
+    let mut result = Vec::new();
+    for a in page_alliances {
+        let leader = User::find_by_id(a.leader_id)
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+        
+        result.push(AllianceDisplay {
+            id: a.id,
+            name: a.name.clone(),
+            tag: a.tag.clone(),
+            description: a.description.clone(),
+            leader_name: leader.map(|l| l.username).unwrap_or_else(|| "Inconnu".into()),
+            member_count: a.member_count,
+            total_score: a.total_score,
+            recruitment_policy: a.recruitment_policy.clone(),
+            created_at: a.created_at,
+        });
+    }
+
+    Json(json!({
+        "alliances": result,
+        "total": total,
+        "page": page,
+        "per_page": per_page
+    })).into_response()
+}
+
+/// Créer une nouvelle alliance
+pub async fn create_alliance_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<CreateAlliancePayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // Vérifier que l'utilisateur n'est pas déjà dans une alliance
+    let existing = AllianceMember::find()
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    if existing.is_some() {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous êtes déjà membre d'une alliance"}))).into_response();
+    }
+
+    // Valider le nom (3-20 caractères)
+    let name = payload.name.trim();
+    if name.len() < 3 || name.len() > 20 {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Le nom doit faire entre 3 et 20 caractères"}))).into_response();
+    }
+
+    // Valider le tag (2-5 caractères)
+    let tag = payload.tag.trim().to_uppercase();
+    if tag.len() < 2 || tag.len() > 5 {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Le tag doit faire entre 2 et 5 caractères"}))).into_response();
+    }
+
+    // Vérifier unicité
+    let name_exists = Alliance::find()
+        .filter(alliance::Column::Name.eq(name))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+
+    if name_exists {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Ce nom d'alliance est déjà pris"}))).into_response();
+    }
+
+    let tag_exists = Alliance::find()
+        .filter(alliance::Column::Tag.eq(&tag))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+
+    if tag_exists {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Ce tag est déjà pris"}))).into_response();
+    }
+
+    // Récupérer le score de l'utilisateur (somme des scores de ses planètes)
+    let user_planets = Planet::find()
+        .filter(planet::Column::OwnerId.eq(user_id))
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let user_score: i64 = user_planets.iter()
+        .map(|p| calculate_planet_score(p))
+        .sum();
+
+    let now = Utc::now().naive_utc();
+    let alliance_id = Uuid::new_v4();
+
+    // Créer l'alliance
+    let new_alliance = alliance::ActiveModel {
+        id: Set(alliance_id),
+        name: Set(name.to_string()),
+        tag: Set(tag.clone()),
+        description: Set(payload.description),
+        internal_message: Set(None),
+        leader_id: Set(user_id),
+        member_count: Set(1),
+        total_score: Set(user_score),
+        recruitment_policy: Set(payload.recruitment_policy.unwrap_or_else(|| "invite_only".into())),
+        min_level_required: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+
+    if let Err(e) = new_alliance.insert(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("Erreur création: {}", e)}))).into_response();
+    }
+
+    // Ajouter le fondateur comme membre (leader)
+    let new_member = alliance_member::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        alliance_id: Set(alliance_id),
+        user_id: Set(user_id),
+        role: Set("leader".into()),
+        score: Set(user_score),
+        joined_at: Set(now),
+        last_active: Set(now),
+    };
+
+    if let Err(e) = new_member.insert(&state.db).await {
+        // Rollback: supprimer l'alliance
+        let _ = Alliance::delete_by_id(alliance_id).exec(&state.db).await;
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("Erreur création membre: {}", e)}))).into_response();
+    }
+
+    (StatusCode::CREATED, Json(json!({
+        "id": alliance_id,
+        "name": name,
+        "tag": tag,
+        "message": "Alliance créée avec succès !"
+    }))).into_response()
+}
+
+/// Détails d'une alliance
+pub async fn get_alliance_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id = params.get("user_id")
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    let leader = User::find_by_id(alliance.leader_id)
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    // Récupérer les membres
+    let members_raw = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .order_by_desc(alliance_member::Column::Score)
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let mut members = Vec::new();
+    let mut is_member = false;
+    let mut user_role = None;
+
+    for m in members_raw {
+        let member_user = User::find_by_id(m.user_id)
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+        if let Some(uid) = user_id {
+            if m.user_id == uid {
+                is_member = true;
+                user_role = Some(m.role.clone());
+            }
+        }
+
+        members.push(MemberDisplay {
+            user_id: m.user_id,
+            username: member_user.map(|u| u.username).unwrap_or_else(|| "Inconnu".into()),
+            role: m.role,
+            score: m.score,
+            joined_at: m.joined_at,
+            last_active: m.last_active,
+        });
+    }
+
+    // Ne pas montrer le message interne aux non-membres
+    let internal_message = if is_member {
+        alliance.internal_message.clone()
+    } else {
+        None
+    };
+
+    Json(AllianceDetailDisplay {
+        id: alliance.id,
+        name: alliance.name,
+        tag: alliance.tag,
+        description: alliance.description,
+        internal_message,
+        leader_id: alliance.leader_id,
+        leader_name: leader.map(|l| l.username).unwrap_or_else(|| "Inconnu".into()),
+        member_count: alliance.member_count,
+        total_score: alliance.total_score,
+        recruitment_policy: alliance.recruitment_policy,
+        min_level_required: alliance.min_level_required,
+        members,
+        created_at: alliance.created_at,
+        is_member,
+        user_role,
+    }).into_response()
+}
+
+/// Modifier une alliance (leader/officier seulement)
+pub async fn update_alliance_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<UpdateAlliancePayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // Vérifier les permissions
+    let member = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let role = match member {
+        Some(m) => m.role,
+        None => return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous n'êtes pas membre de cette alliance"}))).into_response(),
+    };
+
+    if role != "leader" && role != "officer" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Permissions insuffisantes"}))).into_response();
+    }
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    let mut active: alliance::ActiveModel = alliance.into();
+    active.updated_at = Set(Utc::now().naive_utc());
+
+    if let Some(desc) = payload.description {
+        if desc.len() > 500 {
+            return (StatusCode::BAD_REQUEST, Json(json!({"error": "Description trop longue (max 500 caractères)"}))).into_response();
+        }
+        active.description = Set(Some(desc));
+    }
+
+    if let Some(msg) = payload.internal_message {
+        if msg.len() > 1000 {
+            return (StatusCode::BAD_REQUEST, Json(json!({"error": "Message interne trop long (max 1000 caractères)"}))).into_response();
+        }
+        active.internal_message = Set(Some(msg));
+    }
+
+    if let Some(policy) = payload.recruitment_policy {
+        if !["open", "invite_only", "closed"].contains(&policy.as_str()) {
+            return (StatusCode::BAD_REQUEST, Json(json!({"error": "Politique de recrutement invalide"}))).into_response();
+        }
+        active.recruitment_policy = Set(policy);
+    }
+
+    if let Some(level) = payload.min_level_required {
+        if level < 0 || level > 100 {
+            return (StatusCode::BAD_REQUEST, Json(json!({"error": "Niveau minimum invalide"}))).into_response();
+        }
+        active.min_level_required = Set(level);
+    }
+
+    let _ = active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Alliance mise à jour"}))).into_response()
+}
+
+/// Dissoudre une alliance (leader seulement)
+pub async fn dissolve_alliance_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    if alliance.leader_id != user_id {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Seul le leader peut dissoudre l'alliance"}))).into_response();
+    }
+
+    // Supprimer toutes les invitations
+    let _ = AllianceInvitation::delete_many()
+        .filter(alliance_invitation::Column::AllianceId.eq(alliance_id))
+        .exec(&state.db)
+        .await;
+
+    // Supprimer tous les membres
+    let _ = AllianceMember::delete_many()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .exec(&state.db)
+        .await;
+
+    // Supprimer l'alliance
+    let _ = Alliance::delete_by_id(alliance_id).exec(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Alliance dissoute"}))).into_response()
+}
+
+// ============================================================================
+// HANDLERS: MEMBRES
+// ============================================================================
+
+/// Quitter une alliance
+pub async fn leave_alliance_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    // Si c'est le leader, il ne peut pas quitter (doit dissoudre ou transférer)
+    if alliance.leader_id == user_id {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Le leader ne peut pas quitter. Transférez le leadership ou dissolvez l'alliance."}))).into_response();
+    }
+
+    let member = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    if member.is_none() {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous n'êtes pas membre de cette alliance"}))).into_response();
+    }
+
+    let member = member.unwrap();
+
+    // Supprimer le membre
+    let _ = AllianceMember::delete_by_id(member.id).exec(&state.db).await;
+
+    // Mettre à jour le compteur
+    let mut alliance_active: alliance::ActiveModel = alliance.clone().into();
+    alliance_active.member_count = Set(alliance.member_count - 1);
+    alliance_active.total_score = Set(alliance.total_score - member.score);
+    alliance_active.updated_at = Set(Utc::now().naive_utc());
+    let _ = alliance_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Vous avez quitté l'alliance"}))).into_response()
+}
+
+/// Expulser un membre (leader/officier seulement)
+pub async fn kick_member_handler(
+    Path((alliance_id, target_user_id)): Path<(Uuid, Uuid)>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // On ne peut pas s'expulser soi-même
+    if user_id == target_user_id {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Utilisez 'Quitter l'alliance' pour partir"}))).into_response();
+    }
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    // Vérifier que l'utilisateur est leader ou officier
+    let kicker = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let kicker_role = match kicker {
+        Some(m) => m.role,
+        None => return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous n'êtes pas membre de cette alliance"}))).into_response(),
+    };
+
+    if kicker_role != "leader" && kicker_role != "officer" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Permissions insuffisantes"}))).into_response();
+    }
+
+    // Récupérer la cible
+    let target = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(target_user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let target = match target {
+        Some(t) => t,
+        None => return (StatusCode::NOT_FOUND, Json(json!({"error": "Membre introuvable"}))).into_response(),
+    };
+
+    // Un officier ne peut pas expulser un autre officier ou le leader
+    if kicker_role == "officer" && (target.role == "officer" || target.role == "leader") {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous ne pouvez pas expulser un officier ou le leader"}))).into_response();
+    }
+
+    // On ne peut pas expulser le leader
+    if target.role == "leader" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Impossible d'expulser le leader"}))).into_response();
+    }
+
+    // Supprimer le membre
+    let _ = AllianceMember::delete_by_id(target.id).exec(&state.db).await;
+
+    // Mettre à jour le compteur
+    let mut alliance_active: alliance::ActiveModel = alliance.clone().into();
+    alliance_active.member_count = Set(alliance.member_count - 1);
+    alliance_active.total_score = Set(alliance.total_score - target.score);
+    alliance_active.updated_at = Set(Utc::now().naive_utc());
+    let _ = alliance_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Membre expulsé"}))).into_response()
+}
+
+/// Changer le rôle d'un membre (leader seulement)
+pub async fn change_role_handler(
+    Path((alliance_id, target_user_id)): Path<(Uuid, Uuid)>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<ChangeMemberRolePayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    // Seul le leader peut changer les rôles
+    if alliance.leader_id != user_id {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Seul le leader peut modifier les rôles"}))).into_response();
+    }
+
+    // Valider le nouveau rôle
+    if !["officer", "member"].contains(&payload.role.as_str()) {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Rôle invalide (officer ou member)"}))).into_response();
+    }
+
+    // Si on veut promouvoir quelqu'un leader, utiliser transfer_leadership
+    if payload.role == "leader" {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Utilisez 'Transférer le leadership' pour cela"}))).into_response();
+    }
+
+    let target = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(target_user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let target = match target {
+        Some(t) => t,
+        None => return (StatusCode::NOT_FOUND, Json(json!({"error": "Membre introuvable"}))).into_response(),
+    };
+
+    // On ne peut pas modifier son propre rôle de cette façon
+    if target.user_id == user_id {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous ne pouvez pas modifier votre propre rôle"}))).into_response();
+    }
+
+    let mut target_active: alliance_member::ActiveModel = target.into();
+    target_active.role = Set(payload.role.clone());
+    let _ = target_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": format!("Rôle changé en {}", payload.role)}))).into_response()
+}
+
+/// Transférer le leadership (leader seulement)
+pub async fn transfer_leadership_handler(
+    Path((alliance_id, target_user_id)): Path<(Uuid, Uuid)>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let alliance = match Alliance::find_by_id(alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    if alliance.leader_id != user_id {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Seul le leader peut transférer le leadership"}))).into_response();
+    }
+
+    if target_user_id == user_id {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous êtes déjà le leader"}))).into_response();
+    }
+
+    // Vérifier que la cible est membre
+    let target = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(target_user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let target = match target {
+        Some(t) => t,
+        None => return (StatusCode::NOT_FOUND, Json(json!({"error": "Membre introuvable"}))).into_response(),
+    };
+
+    // Récupérer l'ancien leader
+    let old_leader = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .unwrap();
+
+    // Mettre à jour les rôles
+    let mut old_active: alliance_member::ActiveModel = old_leader.into();
+    old_active.role = Set("officer".into()); // L'ancien leader devient officier
+    let _ = old_active.update(&state.db).await;
+
+    let mut target_active: alliance_member::ActiveModel = target.into();
+    target_active.role = Set("leader".into());
+    let _ = target_active.update(&state.db).await;
+
+    // Mettre à jour l'alliance
+    let mut alliance_active: alliance::ActiveModel = alliance.into();
+    alliance_active.leader_id = Set(target_user_id);
+    alliance_active.updated_at = Set(Utc::now().naive_utc());
+    let _ = alliance_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Leadership transféré"}))).into_response()
+}
+
+// ============================================================================
+// HANDLERS: INVITATIONS ET CANDIDATURES
+// ============================================================================
+
+/// Inviter un joueur (leader/officier)
+pub async fn invite_player_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<InvitePlayerPayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // Vérifier les permissions
+    let member = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let role = match member {
+        Some(m) => m.role,
+        None => return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous n'êtes pas membre de cette alliance"}))).into_response(),
+    };
+
+    if role != "leader" && role != "officer" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Permissions insuffisantes"}))).into_response();
+    }
+
+    // Trouver le joueur cible
+    let target_user = User::find()
+        .filter(user::Column::Username.eq(&payload.username))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let target_user = match target_user {
+        Some(u) => u,
+        None => return (StatusCode::NOT_FOUND, Json(json!({"error": "Joueur introuvable"}))).into_response(),
+    };
+
+    // Vérifier que le joueur n'est pas déjà dans une alliance
+    let already_member = AllianceMember::find()
+        .filter(alliance_member::Column::UserId.eq(target_user.id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+
+    if already_member {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Ce joueur est déjà dans une alliance"}))).into_response();
+    }
+
+    // Vérifier qu'il n'y a pas déjà une invitation en cours
+    let existing = AllianceInvitation::find()
+        .filter(alliance_invitation::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_invitation::Column::UserId.eq(target_user.id))
+        .filter(alliance_invitation::Column::Status.eq("pending"))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    if existing.is_some() {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Une invitation est déjà en cours pour ce joueur"}))).into_response();
+    }
+
+    let now = Utc::now().naive_utc();
+
+    let invitation = alliance_invitation::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        alliance_id: Set(alliance_id),
+        user_id: Set(target_user.id),
+        invitation_type: Set("invitation".into()),
+        status: Set("pending".into()),
+        message: Set(payload.message),
+        invited_by: Set(Some(user_id)),
+        created_at: Set(now),
+        expires_at: Set(Some(now + chrono::Duration::days(7))),
+    };
+
+    let _ = invitation.insert(&state.db).await;
+
+    // TODO: Notification WebSocket
+
+    (StatusCode::OK, Json(json!({"message": "Invitation envoyée"}))).into_response()
+}
+
+/// Postuler à une alliance (joueur)
+pub async fn apply_to_alliance_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<ApplicationPayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // Vérifier que l'utilisateur n'est pas déjà dans une alliance
+    let already_member = AllianceMember::find()
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+
+    if already_member {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous êtes déjà dans une alliance"}))).into_response();
+    }
+
+    let alliance = match Alliance::find_by_id(payload.alliance_id).one(&state.db).await {
+        Ok(Some(a)) => a,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Alliance introuvable"}))).into_response(),
+    };
+
+    if alliance.recruitment_policy == "closed" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Cette alliance n'accepte pas de nouvelles candidatures"}))).into_response();
+    }
+
+    // Si l'alliance est ouverte, rejoindre directement
+    if alliance.recruitment_policy == "open" {
+        return join_alliance_directly(&state, user_id, &alliance).await;
+    }
+
+    // Vérifier qu'il n'y a pas déjà une candidature en cours
+    let existing = AllianceInvitation::find()
+        .filter(alliance_invitation::Column::AllianceId.eq(payload.alliance_id))
+        .filter(alliance_invitation::Column::UserId.eq(user_id))
+        .filter(alliance_invitation::Column::Status.eq("pending"))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    if existing.is_some() {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous avez déjà une candidature en cours"}))).into_response();
+    }
+
+    let now = Utc::now().naive_utc();
+
+    let application = alliance_invitation::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        alliance_id: Set(payload.alliance_id),
+        user_id: Set(user_id),
+        invitation_type: Set("application".into()),
+        status: Set("pending".into()),
+        message: Set(payload.message),
+        invited_by: Set(None),
+        created_at: Set(now),
+        expires_at: Set(Some(now + chrono::Duration::days(30))),
+    };
+
+    let _ = application.insert(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Candidature envoyée"}))).into_response()
+}
+
+/// Récupérer les invitations/candidatures d'un utilisateur
+pub async fn get_my_invitations_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let invitations = AllianceInvitation::find()
+        .filter(alliance_invitation::Column::UserId.eq(user_id))
+        .filter(alliance_invitation::Column::Status.eq("pending"))
+        .order_by_desc(alliance_invitation::Column::CreatedAt)
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let mut result = Vec::new();
+    for inv in invitations {
+        let alliance = Alliance::find_by_id(inv.alliance_id)
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+        let user = User::find_by_id(inv.user_id)
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+        if let Some(a) = alliance {
+            result.push(InvitationDisplay {
+                id: inv.id,
+                alliance_id: inv.alliance_id,
+                alliance_name: a.name,
+                alliance_tag: a.tag,
+                user_id: inv.user_id,
+                username: user.map(|u| u.username).unwrap_or_else(|| "Inconnu".into()),
+                invitation_type: inv.invitation_type,
+                status: inv.status,
+                message: inv.message,
+                created_at: inv.created_at,
+            });
+        }
+    }
+
+    Json(result).into_response()
+}
+
+/// Récupérer les candidatures d'une alliance (leader/officier)
+pub async fn get_alliance_applications_handler(
+    Path(alliance_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    // Vérifier les permissions
+    let member = AllianceMember::find()
+        .filter(alliance_member::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let role = match member {
+        Some(m) => m.role,
+        None => return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous n'êtes pas membre de cette alliance"}))).into_response(),
+    };
+
+    if role != "leader" && role != "officer" {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "Permissions insuffisantes"}))).into_response();
+    }
+
+    let invitations = AllianceInvitation::find()
+        .filter(alliance_invitation::Column::AllianceId.eq(alliance_id))
+        .filter(alliance_invitation::Column::Status.eq("pending"))
+        .order_by_desc(alliance_invitation::Column::CreatedAt)
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let alliance = Alliance::find_by_id(alliance_id)
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    let mut result = Vec::new();
+    for inv in invitations {
+        let user = User::find_by_id(inv.user_id)
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+        if let Some(a) = &alliance {
+            result.push(InvitationDisplay {
+                id: inv.id,
+                alliance_id: inv.alliance_id,
+                alliance_name: a.name.clone(),
+                alliance_tag: a.tag.clone(),
+                user_id: inv.user_id,
+                username: user.map(|u| u.username).unwrap_or_else(|| "Inconnu".into()),
+                invitation_type: inv.invitation_type,
+                status: inv.status,
+                message: inv.message,
+                created_at: inv.created_at,
+            });
+        }
+    }
+
+    Json(result).into_response()
+}
+
+/// Répondre à une invitation (accepter/refuser)
+pub async fn respond_to_invitation_handler(
+    Path(invitation_id): Path<Uuid>,
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+    Json(payload): Json<HandleInvitationPayload>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let invitation = match AllianceInvitation::find_by_id(invitation_id).one(&state.db).await {
+        Ok(Some(i)) => i,
+        _ => return (StatusCode::NOT_FOUND, Json(json!({"error": "Invitation introuvable"}))).into_response(),
+    };
+
+    if invitation.status != "pending" {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "Cette invitation n'est plus valide"}))).into_response();
+    }
+
+    // Si c'est une invitation (de l'alliance vers le joueur)
+    if invitation.invitation_type == "invitation" {
+        if invitation.user_id != user_id {
+            return (StatusCode::FORBIDDEN, Json(json!({"error": "Cette invitation ne vous est pas destinée"}))).into_response();
+        }
+
+        if payload.accept {
+            // Vérifier que le joueur n'est pas déjà dans une alliance
+            let already_member = AllianceMember::find()
+                .filter(alliance_member::Column::UserId.eq(user_id))
+                .one(&state.db)
+                .await
+                .ok()
+                .flatten()
+                .is_some();
+
+            if already_member {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": "Vous êtes déjà dans une alliance"}))).into_response();
+            }
+
+            // Rejoindre l'alliance
+            let alliance = Alliance::find_by_id(invitation.alliance_id)
+                .one(&state.db)
+                .await
+                .ok()
+                .flatten();
+
+            if let Some(a) = alliance {
+                let result = join_alliance_directly(&state, user_id, &a).await;
+                
+                // Marquer l'invitation comme acceptée
+                let mut inv_active: alliance_invitation::ActiveModel = invitation.into();
+                inv_active.status = Set("accepted".into());
+                let _ = inv_active.update(&state.db).await;
+
+                return result;
+            }
+        }
+    }
+    // Si c'est une candidature (du joueur vers l'alliance)
+    else if invitation.invitation_type == "application" {
+        // Vérifier que l'utilisateur est leader/officier
+        let member = AllianceMember::find()
+            .filter(alliance_member::Column::AllianceId.eq(invitation.alliance_id))
+            .filter(alliance_member::Column::UserId.eq(user_id))
+            .one(&state.db)
+            .await
+            .ok()
+            .flatten();
+
+        let role = match member {
+            Some(m) => m.role,
+            None => return (StatusCode::FORBIDDEN, Json(json!({"error": "Vous n'êtes pas autorisé à gérer les candidatures"}))).into_response(),
+        };
+
+        if role != "leader" && role != "officer" {
+            return (StatusCode::FORBIDDEN, Json(json!({"error": "Permissions insuffisantes"}))).into_response();
+        }
+
+        if payload.accept {
+            // Vérifier que le candidat n'est pas déjà dans une alliance
+            let already_member = AllianceMember::find()
+                .filter(alliance_member::Column::UserId.eq(invitation.user_id))
+                .one(&state.db)
+                .await
+                .ok()
+                .flatten()
+                .is_some();
+
+            if already_member {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": "Ce joueur est déjà dans une alliance"}))).into_response();
+            }
+
+            let alliance = Alliance::find_by_id(invitation.alliance_id)
+                .one(&state.db)
+                .await
+                .ok()
+                .flatten();
+
+            if let Some(a) = alliance {
+                let result = join_alliance_directly(&state, invitation.user_id, &a).await;
+                
+                // Marquer l'invitation comme acceptée
+                let mut inv_active: alliance_invitation::ActiveModel = invitation.into();
+                inv_active.status = Set("accepted".into());
+                let _ = inv_active.update(&state.db).await;
+
+                return result;
+            }
+        }
+    }
+
+    // Si on arrive ici, c'est un refus
+    let mut inv_active: alliance_invitation::ActiveModel = invitation.into();
+    inv_active.status = Set("rejected".into());
+    let _ = inv_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({"message": "Invitation refusée"}))).into_response()
+}
+
+/// Récupérer l'alliance de l'utilisateur connecté
+pub async fn get_my_alliance_handler(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let user_id_str = params.get("user_id").unwrap_or(&String::new()).to_string();
+    let user_id = match Uuid::parse_str(&user_id_str) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::UNAUTHORIZED, Json(json!({"error": "Utilisateur invalide"}))).into_response(),
+    };
+
+    let member = AllianceMember::find()
+        .filter(alliance_member::Column::UserId.eq(user_id))
+        .one(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+    match member {
+        Some(m) => {
+            // Rediriger vers get_alliance_handler
+            let alliance = Alliance::find_by_id(m.alliance_id)
+                .one(&state.db)
+                .await
+                .ok()
+                .flatten();
+
+            if let Some(a) = alliance {
+                Json(json!({
+                    "has_alliance": true,
+                    "alliance_id": a.id,
+                    "alliance_name": a.name,
+                    "alliance_tag": a.tag,
+                    "user_role": m.role
+                })).into_response()
+            } else {
+                Json(json!({ "has_alliance": false })).into_response()
+            }
+        },
+        None => Json(json!({ "has_alliance": false })).into_response(),
+    }
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+async fn join_alliance_directly(
+    state: &AppState,
+    user_id: Uuid,
+    alliance: &alliance::Model,
+) -> axum::response::Response {
+    let now = Utc::now().naive_utc();
+
+    // Calculer le score de l'utilisateur
+    let user_planets = Planet::find()
+        .filter(planet::Column::OwnerId.eq(user_id))
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let user_score: i64 = user_planets.iter()
+        .map(|p| calculate_planet_score(p))
+        .sum();
+
+    // Créer le membre
+    let new_member = alliance_member::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        alliance_id: Set(alliance.id),
+        user_id: Set(user_id),
+        role: Set("member".into()),
+        score: Set(user_score),
+        joined_at: Set(now),
+        last_active: Set(now),
+    };
+
+    if let Err(e) = new_member.insert(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": format!("Erreur: {}", e)}))).into_response();
+    }
+
+    // Mettre à jour l'alliance
+    let mut alliance_active: alliance::ActiveModel = alliance.clone().into();
+    alliance_active.member_count = Set(alliance.member_count + 1);
+    alliance_active.total_score = Set(alliance.total_score + user_score);
+    alliance_active.updated_at = Set(now);
+    let _ = alliance_active.update(&state.db).await;
+
+    (StatusCode::OK, Json(json!({
+        "message": format!("Bienvenue dans [{}] {} !", alliance.tag, alliance.name),
+        "alliance_id": alliance.id
+    }))).into_response()
+}
+
+fn calculate_planet_score(planet: &planet::Model) -> i64 {
+    let building_score = (
+        planet.metal_mine_level +
+        planet.crystal_mine_level +
+        planet.deuterium_mine_level +
+        planet.solar_plant_level +
+        planet.shipyard_level +
+        planet.research_lab_level +
+        planet.hangar_level
+    ) as i64 * 100;
+
+    let tech_score = (
+        planet.energy_tech_level +
+        planet.laser_battery_level +
+        planet.espionage_tech_level +
+        planet.armour_tech_level
+    ) as i64 * 150;
+
+    let fleet_score = (
+        planet.light_hunter_count * 10 +
+        planet.cruiser_count * 50 +
+        planet.transporter_count * 5 +
+        planet.colony_ship_count * 100 +
+        planet.recycler_count * 20 +
+        planet.spy_probe_count * 1
+    ) as i64;
+
+    let defense_score = (
+        planet.missile_launcher_count * 5 +
+        planet.plasma_turret_count * 50
+    ) as i64;
+
+    building_score + tech_score + fleet_score + defense_score
+}

--- a/backend/src/entities/alliance.rs
+++ b/backend/src/entities/alliance.rs
@@ -1,0 +1,72 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "alliance")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    
+    /// Nom unique de l'alliance (3-20 caractères)
+    #[sea_orm(unique)]
+    pub name: String,
+    
+    /// Tag court affiché devant le pseudo (2-5 caractères, ex: [TAG])
+    #[sea_orm(unique)]
+    pub tag: String,
+    
+    /// Description de l'alliance (max 500 caractères)
+    #[sea_orm(column_type = "Text", nullable)]
+    pub description: Option<String>,
+    
+    /// Message interne visible uniquement par les membres
+    #[sea_orm(column_type = "Text", nullable)]
+    pub internal_message: Option<String>,
+    
+    /// ID du fondateur (leader actuel)
+    pub leader_id: Uuid,
+    
+    /// Nombre de membres (dénormalisé pour performance)
+    #[sea_orm(default_value = 1)]
+    pub member_count: i32,
+    
+    /// Score total de l'alliance (somme des scores des membres)
+    #[sea_orm(default_value = 0)]
+    pub total_score: i64,
+    
+    /// Politique de recrutement: "open", "invite_only", "closed"
+    #[sea_orm(default_value = "invite_only")]
+    pub recruitment_policy: String,
+    
+    /// Niveau minimum requis pour rejoindre (si open)
+    #[sea_orm(default_value = 0)]
+    pub min_level_required: i32,
+    
+    /// Date de création
+    pub created_at: chrono::NaiveDateTime,
+    
+    /// Dernière mise à jour
+    pub updated_at: chrono::NaiveDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::alliance_member::Entity")]
+    Members,
+    #[sea_orm(has_many = "super::alliance_invitation::Entity")]
+    Invitations,
+}
+
+impl Related<super::alliance_member::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Members.def()
+    }
+}
+
+impl Related<super::alliance_invitation::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Invitations.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/entities/alliance_invitation.rs
+++ b/backend/src/entities/alliance_invitation.rs
@@ -1,0 +1,65 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "alliance_invitation")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    
+    /// ID de l'alliance
+    pub alliance_id: Uuid,
+    
+    /// ID de l'utilisateur invité/candidat
+    pub user_id: Uuid,
+    
+    /// Type: "invitation" (de l'alliance vers le joueur) ou "application" (candidature du joueur)
+    pub invitation_type: String,
+    
+    /// Statut: "pending", "accepted", "rejected", "cancelled"
+    #[sea_orm(default_value = "pending")]
+    pub status: String,
+    
+    /// Message optionnel (motivation pour candidature ou message d'invitation)
+    #[sea_orm(column_type = "Text", nullable)]
+    pub message: Option<String>,
+    
+    /// ID de l'utilisateur qui a créé l'invitation (officier/leader)
+    pub invited_by: Option<Uuid>,
+    
+    /// Date de création
+    pub created_at: chrono::NaiveDateTime,
+    
+    /// Date d'expiration (optionnelle)
+    pub expires_at: Option<chrono::NaiveDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::alliance::Entity",
+        from = "Column::AllianceId",
+        to = "super::alliance::Column::Id"
+    )]
+    Alliance,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::UserId",
+        to = "super::user::Column::Id"
+    )]
+    User,
+}
+
+impl Related<super::alliance::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Alliance.def()
+    }
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/entities/alliance_member.rs
+++ b/backend/src/entities/alliance_member.rs
@@ -1,0 +1,62 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "alliance_member")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    
+    /// ID de l'alliance
+    pub alliance_id: Uuid,
+    
+    /// ID de l'utilisateur membre
+    pub user_id: Uuid,
+    
+    /// Rôle dans l'alliance: "leader", "officer", "member"
+    /// - leader: tous les droits (1 seul par alliance)
+    /// - officer: peut inviter, accepter candidatures, kick membres
+    /// - member: membre de base
+    #[sea_orm(default_value = "member")]
+    pub role: String,
+    
+    /// Score du membre au moment du calcul (pour classement interne)
+    #[sea_orm(default_value = 0)]
+    pub score: i64,
+    
+    /// Date d'entrée dans l'alliance
+    pub joined_at: chrono::NaiveDateTime,
+    
+    /// Dernière activité
+    pub last_active: chrono::NaiveDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::alliance::Entity",
+        from = "Column::AllianceId",
+        to = "super::alliance::Column::Id"
+    )]
+    Alliance,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::UserId",
+        to = "super::user::Column::Id"
+    )]
+    User,
+}
+
+impl Related<super::alliance::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Alliance.def()
+    }
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/entities/mod.rs
+++ b/backend/src/entities/mod.rs
@@ -16,3 +16,8 @@ pub mod server_resource_stats;
 pub mod market_price_history;
 pub mod server_config;
 pub mod resource_slot;
+
+// Alliance system
+pub mod alliance;
+pub mod alliance_member;
+pub mod alliance_invitation;

--- a/backend/src/entities/prelude.rs
+++ b/backend/src/entities/prelude.rs
@@ -14,3 +14,8 @@ pub use super :: server_resource_stats :: Entity as ServerResourceStats ;
 pub use super :: market_price_history :: Entity as MarketPriceHistory ;
 pub use super :: server_config :: Entity as ServerConfig ;
 pub use super :: resource_slot :: Entity as ResourceSlot ;
+
+// Alliance system
+pub use super :: alliance :: Entity as Alliance ;
+pub use super :: alliance_member :: Entity as AllianceMember ;
+pub use super :: alliance_invitation :: Entity as AllianceInvitation ;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ pub mod entities;
 pub mod config;
 pub mod messaging;
 pub mod websocket;
+pub mod alliance;
 
 // Structures partagées - doivent être définies APRÈS entities mais AVANT admin
 use entities::{prelude::ServerConfig, server_config};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,6 +42,7 @@ mod admin;
 mod messaging;
 mod market;
 mod websocket;
+mod alliance;
 use config::Config;
 use backend::AppState;
 use websocket::WsState;
@@ -249,6 +250,22 @@ async fn main() {
         .route("/admin/user/:id/email", patch(admin::update_email_handler))
         .route("/admin/user/:id/reset-password", post(admin::reset_password_handler))
         .route("/admin/user/:id", delete(admin::delete_user_handler))
+        // Alliance system
+        .route("/alliances", get(alliance::list_alliances_handler))
+        .route("/alliances", post(alliance::create_alliance_handler))
+        .route("/alliances/my", get(alliance::get_my_alliance_handler))
+        .route("/alliances/invitations", get(alliance::get_my_invitations_handler))
+        .route("/alliances/apply", post(alliance::apply_to_alliance_handler))
+        .route("/alliances/:id", get(alliance::get_alliance_handler))
+        .route("/alliances/:id", patch(alliance::update_alliance_handler))
+        .route("/alliances/:id", delete(alliance::dissolve_alliance_handler))
+        .route("/alliances/:id/leave", post(alliance::leave_alliance_handler))
+        .route("/alliances/:id/invite", post(alliance::invite_player_handler))
+        .route("/alliances/:id/applications", get(alliance::get_alliance_applications_handler))
+        .route("/alliances/:id/kick/:user_id", delete(alliance::kick_member_handler))
+        .route("/alliances/:id/role/:user_id", patch(alliance::change_role_handler))
+        .route("/alliances/:id/transfer/:user_id", post(alliance::transfer_leadership_handler))
+        .route("/alliances/invitations/:invitation_id/respond", post(alliance::respond_to_invitation_handler))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import SpyModal from './components/SpyModal';
 import MyPlanets from './components/MyPlanets';
 import Marketplace from './components/Marketplace';
 import ProductionStats from './components/ProductionStats';
+import AllianceView from './components/AllianceView';
 import { FloatingResourceGain, useResourceGainAnimation } from './components/FloatingResourceGain';
 import { useKeyboardShortcuts, useShortcutFeedback, ShortcutsHelpModal } from './hooks/useKeyboardShortcuts';
 import { useSoundEffects, AudioUnlockPrompt } from './hooks/useSoundEffects';
@@ -35,7 +36,7 @@ import { Toaster, toast } from "sonner";
 import {
   LayoutDashboard, Pickaxe, Hammer,
   ShieldCheck, FlaskConical, Telescope, Trophy, ScrollText, Globe, Truck,
-  Settings as SettingsIcon, Mail, Factory, Rocket, X, Database, ShoppingCart, Keyboard, LogOut, MessageSquarePlus, FileText, Activity, Map
+  Settings as SettingsIcon, Mail, Factory, Rocket, X, Database, ShoppingCart, Keyboard, LogOut, MessageSquarePlus, FileText, Activity, Map, Shield
 } from "lucide-react";
 
 interface CombatReport {
@@ -48,7 +49,7 @@ interface CombatReport {
   };
 }
 
-type TabType = 'overview' | 'galaxy' | 'myplanets' | 'resources' | 'facilities' | 'shipyard' | 'defenses' | 'tech' | 'expedition' | 'ranking' | 'reports' | 'settings' | 'messages' | 'market' | 'admin' | 'changelog' | 'stats';
+type TabType = 'overview' | 'galaxy' | 'myplanets' | 'resources' | 'facilities' | 'shipyard' | 'defenses' | 'tech' | 'expedition' | 'ranking' | 'reports' | 'settings' | 'messages' | 'market' | 'admin' | 'changelog' | 'stats' | 'alliance';
 
 export default function App() {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
@@ -515,6 +516,7 @@ export default function App() {
     { id: 'expedition', label: 'Expéditions', icon: Telescope, category: 'MILITAIRE' },
     
     { id: 'ranking', label: 'Classement', icon: Trophy, category: 'DONNÉES' },
+    { id: 'alliance', label: 'Alliance', icon: Shield, category: 'DONNÉES' },
     { id: 'stats', label: 'Statistiques', icon: Activity, category: 'DONNÉES' },
     { id: 'reports', label: 'Rapports', icon: ScrollText, category: 'DONNÉES' },
     { id: 'changelog', label: 'Changelog', icon: FileText, category: 'SYSTÈME' },
@@ -767,6 +769,7 @@ export default function App() {
                     {activeTab === 'myplanets' && <MyPlanets currentPlanetId={planet.id} onSelectPlanet={(id) => { switchPlanet(id); setActiveTab('overview'); }} />}
                     {activeTab === 'messages' && <MessagesView token={token!} userId={userId!} initialRecipient={messageRecipient} />}
                     {activeTab === 'ranking' && <Leaderboard currentPlanetId={planet.id} onAttack={handlePrepareAttack} onSpy={handleSpy} onSendMessage={handleOpenMessage} />}
+                    {activeTab === 'alliance' && <AllianceView userId={userId!} token={token!} onOpenMessage={handleOpenMessage} />}
                     {activeTab === 'stats' && <ProductionStats planet={planet} speedFactor={speedFactor} />}
                     
                     {activeTab === 'resources' && <ResourceDisplay planet={planet} onUpgrade={fetchPlanet} speedFactor={speedFactor} />}

--- a/frontend/src/components/AllianceView.tsx
+++ b/frontend/src/components/AllianceView.tsx
@@ -1,0 +1,1130 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Badge } from './ui/badge';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogDescription,
+  DialogFooter 
+} from './ui/dialog';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+import { toast } from 'sonner';
+import { apiUrl } from '@/config/api';
+import { 
+  Shield, Crown, Users, Star, Plus, Search, UserPlus, 
+  LogOut, Settings, Trash2, UserMinus, ChevronUp, ChevronDown,
+  Mail, Clock, Check, X, RefreshCw, Award, Swords
+} from 'lucide-react';
+
+interface AllianceViewProps {
+  userId: string;
+  token: string;
+  onOpenMessage?: (username: string) => void;
+}
+
+interface Alliance {
+  id: string;
+  name: string;
+  tag: string;
+  description?: string;
+  internal_message?: string;
+  leader_id: string;
+  leader_name: string;
+  member_count: number;
+  total_score: number;
+  recruitment_policy: string;
+  min_level_required: number;
+  members?: Member[];
+  created_at: string;
+  is_member?: boolean;
+  user_role?: string;
+}
+
+interface Member {
+  user_id: string;
+  username: string;
+  role: string;
+  score: number;
+  joined_at: string;
+  last_active: string;
+}
+
+interface Invitation {
+  id: string;
+  alliance_id: string;
+  alliance_name: string;
+  alliance_tag: string;
+  user_id: string;
+  username: string;
+  invitation_type: string;
+  status: string;
+  message?: string;
+  created_at: string;
+}
+
+interface MyAllianceInfo {
+  has_alliance: boolean;
+  alliance_id?: string;
+  alliance_name?: string;
+  alliance_tag?: string;
+  user_role?: string;
+}
+
+type ViewMode = 'list' | 'detail' | 'create' | 'manage';
+
+export function AllianceView({ userId, token, onOpenMessage }: AllianceViewProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [myAlliance, setMyAlliance] = useState<MyAllianceInfo | null>(null);
+  const [alliances, setAlliances] = useState<Alliance[]>([]);
+  const [selectedAlliance, setSelectedAlliance] = useState<Alliance | null>(null);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [applications, setApplications] = useState<Invitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
+  
+  // Modals
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showApplyModal, setShowApplyModal] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [showConfirmLeave, setShowConfirmLeave] = useState(false);
+  const [showConfirmDissolve, setShowConfirmDissolve] = useState(false);
+  
+  // Form states
+  const [createForm, setCreateForm] = useState({ name: '', tag: '', description: '' });
+  const [inviteUsername, setInviteUsername] = useState('');
+  const [inviteMessage, setInviteMessage] = useState('');
+  const [applyMessage, setApplyMessage] = useState('');
+  const [settingsForm, setSettingsForm] = useState({
+    description: '',
+    internal_message: '',
+    recruitment_policy: 'invite_only',
+    min_level_required: 0
+  });
+
+  // Fetch functions
+  const fetchMyAlliance = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/my?user_id=${userId}`), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setMyAlliance(data);
+      
+      if (data.has_alliance && data.alliance_id) {
+        fetchAllianceDetails(data.alliance_id);
+        setViewMode('detail');
+      }
+    } catch (e) {
+      console.error('Error fetching my alliance:', e);
+    }
+  }, [userId, token]);
+
+  const fetchAlliances = useCallback(async () => {
+    try {
+      const searchParam = searchTerm ? `&search=${encodeURIComponent(searchTerm)}` : '';
+      const res = await fetch(apiUrl(`/alliances?user_id=${userId}${searchParam}`), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setAlliances(data.alliances || []);
+    } catch (e) {
+      console.error('Error fetching alliances:', e);
+    }
+  }, [userId, token, searchTerm]);
+
+  const fetchAllianceDetails = useCallback(async (allianceId: string) => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/${allianceId}?user_id=${userId}`), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setSelectedAlliance(data);
+    } catch (e) {
+      console.error('Error fetching alliance details:', e);
+    }
+  }, [userId, token]);
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/invitations?user_id=${userId}`), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setInvitations(data.filter((i: Invitation) => i.invitation_type === 'invitation'));
+    } catch (e) {
+      console.error('Error fetching invitations:', e);
+    }
+  }, [userId, token]);
+
+  const fetchApplications = useCallback(async (allianceId: string) => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/${allianceId}/applications?user_id=${userId}`), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setApplications(data);
+    } catch (e) {
+      console.error('Error fetching applications:', e);
+    }
+  }, [userId, token]);
+
+  // Initial load
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      await fetchMyAlliance();
+      await fetchAlliances();
+      await fetchInvitations();
+      setLoading(false);
+    };
+    load();
+  }, [fetchMyAlliance, fetchAlliances, fetchInvitations]);
+
+  // Refresh alliance details when viewing own alliance
+  useEffect(() => {
+    if (selectedAlliance?.is_member && (myAlliance?.user_role === 'leader' || myAlliance?.user_role === 'officer')) {
+      fetchApplications(selectedAlliance.id);
+    }
+  }, [selectedAlliance, myAlliance, fetchApplications]);
+
+  // Actions
+  const handleCreateAlliance = async () => {
+    if (!createForm.name || !createForm.tag) {
+      toast.error('Nom et tag requis');
+      return;
+    }
+
+    try {
+      const res = await fetch(apiUrl(`/alliances?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(createForm)
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success('Alliance créée !', { description: data.message });
+        setShowCreateModal(false);
+        setCreateForm({ name: '', tag: '', description: '' });
+        fetchMyAlliance();
+        fetchAlliances();
+      } else {
+        toast.error(data.error || 'Erreur création');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleApplyToAlliance = async (allianceId: string) => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/apply?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ alliance_id: allianceId, message: applyMessage || null })
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message || 'Candidature envoyée !');
+        setShowApplyModal(false);
+        setApplyMessage('');
+        if (data.alliance_id) {
+          fetchMyAlliance();
+        }
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleRespondToInvitation = async (invitationId: string, accept: boolean) => {
+    try {
+      const res = await fetch(apiUrl(`/alliances/invitations/${invitationId}/respond?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ accept })
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message);
+        fetchInvitations();
+        if (accept) {
+          fetchMyAlliance();
+        }
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleInvitePlayer = async () => {
+    if (!inviteUsername || !selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}/invite?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ username: inviteUsername, message: inviteMessage || null })
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message || 'Invitation envoyée !');
+        setShowInviteModal(false);
+        setInviteUsername('');
+        setInviteMessage('');
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleLeaveAlliance = async () => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}/leave?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message);
+        setShowConfirmLeave(false);
+        setSelectedAlliance(null);
+        setMyAlliance({ has_alliance: false });
+        setViewMode('list');
+        fetchAlliances();
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleDissolveAlliance = async () => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}?user_id=${userId}`), {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message || 'Alliance dissoute');
+        setShowConfirmDissolve(false);
+        setSelectedAlliance(null);
+        setMyAlliance({ has_alliance: false });
+        setViewMode('list');
+        fetchAlliances();
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleKickMember = async (targetUserId: string) => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}/kick/${targetUserId}?user_id=${userId}`), {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message || 'Membre expulsé');
+        fetchAllianceDetails(selectedAlliance.id);
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleChangeRole = async (targetUserId: string, newRole: string) => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}/role/${targetUserId}?user_id=${userId}`), {
+        method: 'PATCH',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ role: newRole })
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message);
+        fetchAllianceDetails(selectedAlliance.id);
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleTransferLeadership = async (targetUserId: string) => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}/transfer/${targetUserId}?user_id=${userId}`), {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message);
+        fetchMyAlliance();
+        fetchAllianceDetails(selectedAlliance.id);
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  const handleUpdateSettings = async () => {
+    if (!selectedAlliance) return;
+    
+    try {
+      const res = await fetch(apiUrl(`/alliances/${selectedAlliance.id}?user_id=${userId}`), {
+        method: 'PATCH',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(settingsForm)
+      });
+      
+      const data = await res.json();
+      
+      if (res.ok) {
+        toast.success(data.message || 'Paramètres mis à jour');
+        setShowSettingsModal(false);
+        fetchAllianceDetails(selectedAlliance.id);
+      } else {
+        toast.error(data.error || 'Erreur');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    }
+  };
+
+  // Helpers
+  const getRoleBadge = (role: string) => {
+    switch (role) {
+      case 'leader':
+        return <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/50"><Crown size={10} className="mr-1" /> Leader</Badge>;
+      case 'officer':
+        return <Badge className="bg-blue-500/20 text-blue-400 border-blue-500/50"><Shield size={10} className="mr-1" /> Officier</Badge>;
+      default:
+        return <Badge className="bg-slate-500/20 text-slate-400 border-slate-500/50"><Users size={10} className="mr-1" /> Membre</Badge>;
+    }
+  };
+
+  const getRecruitmentBadge = (policy: string) => {
+    switch (policy) {
+      case 'open':
+        return <Badge className="bg-green-500/20 text-green-400 border-green-500/50">Ouvert</Badge>;
+      case 'invite_only':
+        return <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/50">Sur invitation</Badge>;
+      case 'closed':
+        return <Badge className="bg-red-500/20 text-red-400 border-red-500/50">Fermé</Badge>;
+      default:
+        return null;
+    }
+  };
+
+  const formatScore = (score: number) => {
+    if (score >= 1000000) return `${(score / 1000000).toFixed(1)}M`;
+    if (score >= 1000) return `${(score / 1000).toFixed(1)}K`;
+    return score.toString();
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <RefreshCw className="w-8 h-8 animate-spin text-indigo-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg shadow-indigo-500/25">
+            <Shield className="w-6 h-6 text-white" />
+          </div>
+          <div>
+            <h2 className="text-2xl font-black text-white tracking-tight">ALLIANCES</h2>
+            <p className="text-xs text-slate-400 font-mono">
+              {myAlliance?.has_alliance 
+                ? `[${myAlliance.alliance_tag}] ${myAlliance.alliance_name}`
+                : 'Rejoignez ou créez une alliance'}
+            </p>
+          </div>
+        </div>
+        
+        <div className="flex gap-2">
+          {!myAlliance?.has_alliance && (
+            <Button
+              onClick={() => setShowCreateModal(true)}
+              className="bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700"
+            >
+              <Plus size={16} className="mr-2" /> Créer
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => { 
+              fetchAlliances(); 
+              fetchInvitations(); 
+              if (myAlliance?.has_alliance && myAlliance.alliance_id) {
+                fetchAllianceDetails(myAlliance.alliance_id);
+              }
+            }}
+            className="border-white/10"
+          >
+            <RefreshCw size={16} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Invitations reçues */}
+      {invitations.length > 0 && !myAlliance?.has_alliance && (
+        <Card className="bg-gradient-to-br from-yellow-500/10 to-orange-500/10 border-yellow-500/30">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2 text-yellow-400">
+              <Mail size={16} /> Invitations reçues ({invitations.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {invitations.map(inv => (
+              <div key={inv.id} className="flex items-center justify-between bg-black/30 rounded-lg p-3">
+                <div>
+                  <span className="font-bold text-white">[{inv.alliance_tag}] {inv.alliance_name}</span>
+                  {inv.message && <p className="text-xs text-slate-400 mt-1">{inv.message}</p>}
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={() => handleRespondToInvitation(inv.id, true)} className="bg-green-500/20 hover:bg-green-500/30 text-green-400">
+                    <Check size={14} />
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => handleRespondToInvitation(inv.id, false)} className="text-red-400 hover:bg-red-500/20">
+                    <X size={14} />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Navigation tabs */}
+      <div className="flex gap-2 border-b border-white/10 pb-2">
+        <Button
+          variant={viewMode === 'list' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => setViewMode('list')}
+          className={viewMode === 'list' ? 'bg-indigo-500/20 text-indigo-400' : ''}
+        >
+          <Search size={14} className="mr-2" /> Rechercher
+        </Button>
+        {myAlliance?.has_alliance && (
+          <Button
+            variant={viewMode === 'detail' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => {
+              setViewMode('detail');
+              if (myAlliance.alliance_id) fetchAllianceDetails(myAlliance.alliance_id);
+            }}
+            className={viewMode === 'detail' ? 'bg-indigo-500/20 text-indigo-400' : ''}
+          >
+            <Shield size={14} className="mr-2" /> Mon Alliance
+          </Button>
+        )}
+      </div>
+
+      {/* Liste des alliances */}
+      {viewMode === 'list' && (
+        <div className="space-y-4">
+          {/* Recherche */}
+          <div className="flex gap-2">
+            <Input
+              placeholder="Rechercher par nom ou tag..."
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              className="bg-slate-900/50 border-white/10"
+            />
+            <Button onClick={fetchAlliances} className="bg-indigo-500/20 hover:bg-indigo-500/30">
+              <Search size={16} />
+            </Button>
+          </div>
+
+          {/* Liste */}
+          <div className="grid gap-3">
+            {alliances.map(alliance => (
+              <Card 
+                key={alliance.id} 
+                className="bg-slate-900/50 border-white/10 hover:border-indigo-500/50 transition-all cursor-pointer"
+                onClick={() => {
+                  fetchAllianceDetails(alliance.id);
+                  setViewMode('detail');
+                }}
+              >
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-indigo-500/20 to-purple-500/20 flex items-center justify-center border border-indigo-500/30">
+                        <span className="text-xs font-black text-indigo-400">{alliance.tag}</span>
+                      </div>
+                      <div>
+                        <h3 className="font-bold text-white">{alliance.name}</h3>
+                        <p className="text-xs text-slate-400">
+                          <Crown size={10} className="inline mr-1" /> {alliance.leader_name}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4 text-right">
+                      <div>
+                        <p className="text-lg font-black text-indigo-400">{formatScore(alliance.total_score)}</p>
+                        <p className="text-[10px] text-slate-500 uppercase">Score</p>
+                      </div>
+                      <div>
+                        <p className="text-lg font-black text-white">{alliance.member_count}</p>
+                        <p className="text-[10px] text-slate-500 uppercase">Membres</p>
+                      </div>
+                      {getRecruitmentBadge(alliance.recruitment_policy)}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            
+            {alliances.length === 0 && (
+              <div className="text-center py-12 text-slate-500">
+                <Shield size={48} className="mx-auto mb-4 opacity-30" />
+                <p>Aucune alliance trouvée</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Détail d'une alliance */}
+      {viewMode === 'detail' && selectedAlliance && (
+        <div className="space-y-6">
+          {/* Header de l'alliance */}
+          <Card className="bg-gradient-to-br from-indigo-500/10 to-purple-500/10 border-indigo-500/30">
+            <CardContent className="p-6">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg">
+                    <span className="text-xl font-black text-white">{selectedAlliance.tag}</span>
+                  </div>
+                  <div>
+                    <h2 className="text-2xl font-black text-white">{selectedAlliance.name}</h2>
+                    <p className="text-sm text-slate-400 flex items-center gap-2">
+                      <Crown size={14} className="text-yellow-400" /> {selectedAlliance.leader_name}
+                      <span className="text-slate-600">•</span>
+                      <Users size={14} /> {selectedAlliance.member_count} membres
+                    </p>
+                    {selectedAlliance.is_member && selectedAlliance.user_role && (
+                      <div className="mt-2">{getRoleBadge(selectedAlliance.user_role)}</div>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <p className="text-3xl font-black text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-purple-400">
+                    {formatScore(selectedAlliance.total_score)}
+                  </p>
+                  <p className="text-xs text-slate-500 uppercase tracking-wider">Score total</p>
+                  <div className="mt-2">{getRecruitmentBadge(selectedAlliance.recruitment_policy)}</div>
+                </div>
+              </div>
+              
+              {selectedAlliance.description && (
+                <p className="mt-4 text-sm text-slate-300 border-t border-white/10 pt-4">
+                  {selectedAlliance.description}
+                </p>
+              )}
+              
+              {selectedAlliance.is_member && selectedAlliance.internal_message && (
+                <div className="mt-4 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+                  <p className="text-xs text-yellow-400 font-bold mb-1">📢 Message interne</p>
+                  <p className="text-sm text-yellow-200">{selectedAlliance.internal_message}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Actions */}
+          <div className="flex gap-2 flex-wrap">
+            {!selectedAlliance.is_member && !myAlliance?.has_alliance && (
+              <Button
+                onClick={() => {
+                  if (selectedAlliance.recruitment_policy === 'open') {
+                    handleApplyToAlliance(selectedAlliance.id);
+                  } else if (selectedAlliance.recruitment_policy === 'invite_only') {
+                    setShowApplyModal(true);
+                  }
+                }}
+                disabled={selectedAlliance.recruitment_policy === 'closed'}
+                className="bg-gradient-to-r from-green-500 to-emerald-600"
+              >
+                <UserPlus size={16} className="mr-2" />
+                {selectedAlliance.recruitment_policy === 'open' ? 'Rejoindre' : 'Postuler'}
+              </Button>
+            )}
+            
+            {selectedAlliance.is_member && (
+              <>
+                {(selectedAlliance.user_role === 'leader' || selectedAlliance.user_role === 'officer') && (
+                  <>
+                    <Button onClick={() => setShowInviteModal(true)} variant="outline" className="border-indigo-500/30 text-indigo-400">
+                      <UserPlus size={16} className="mr-2" /> Inviter
+                    </Button>
+                    <Button onClick={() => {
+                      setSettingsForm({
+                        description: selectedAlliance.description || '',
+                        internal_message: selectedAlliance.internal_message || '',
+                        recruitment_policy: selectedAlliance.recruitment_policy,
+                        min_level_required: selectedAlliance.min_level_required
+                      });
+                      setShowSettingsModal(true);
+                    }} variant="outline" className="border-white/10">
+                      <Settings size={16} className="mr-2" /> Paramètres
+                    </Button>
+                  </>
+                )}
+                
+                {selectedAlliance.user_role === 'leader' ? (
+                  <Button onClick={() => setShowConfirmDissolve(true)} variant="outline" className="border-red-500/30 text-red-400">
+                    <Trash2 size={16} className="mr-2" /> Dissoudre
+                  </Button>
+                ) : (
+                  <Button onClick={() => setShowConfirmLeave(true)} variant="outline" className="border-red-500/30 text-red-400">
+                    <LogOut size={16} className="mr-2" /> Quitter
+                  </Button>
+                )}
+              </>
+            )}
+            
+            <Button variant="ghost" onClick={() => setViewMode('list')} className="ml-auto">
+              Retour à la liste
+            </Button>
+          </div>
+
+          {/* Candidatures (pour leader/officier) */}
+          {selectedAlliance.is_member && 
+           (selectedAlliance.user_role === 'leader' || selectedAlliance.user_role === 'officer') &&
+           applications.length > 0 && (
+            <Card className="bg-yellow-500/5 border-yellow-500/30">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm flex items-center gap-2 text-yellow-400">
+                  <Mail size={16} /> Candidatures en attente ({applications.length})
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {applications.filter(a => a.invitation_type === 'application').map(app => (
+                  <div key={app.id} className="flex items-center justify-between bg-black/30 rounded-lg p-3">
+                    <div>
+                      <span className="font-bold text-white">{app.username}</span>
+                      {app.message && <p className="text-xs text-slate-400 mt-1">"{app.message}"</p>}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" onClick={() => handleRespondToInvitation(app.id, true)} className="bg-green-500/20 hover:bg-green-500/30 text-green-400">
+                        <Check size={14} className="mr-1" /> Accepter
+                      </Button>
+                      <Button size="sm" variant="ghost" onClick={() => handleRespondToInvitation(app.id, false)} className="text-red-400 hover:bg-red-500/20">
+                        <X size={14} />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Liste des membres */}
+          <Card className="bg-slate-900/50 border-white/10">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Users size={18} /> Membres ({selectedAlliance.members?.length || 0})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {selectedAlliance.members?.map(member => (
+                  <div key={member.user_id} className="flex items-center justify-between bg-black/30 rounded-lg p-3 hover:bg-black/50 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-indigo-500/30 to-purple-500/30 flex items-center justify-center">
+                        {member.role === 'leader' ? <Crown size={14} className="text-yellow-400" /> :
+                         member.role === 'officer' ? <Shield size={14} className="text-blue-400" /> :
+                         <Users size={14} className="text-slate-400" />}
+                      </div>
+                      <div>
+                        <p className="font-bold text-white flex items-center gap-2">
+                          {member.username}
+                          {getRoleBadge(member.role)}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          Score: {formatScore(member.score)} • Membre depuis {new Date(member.joined_at).toLocaleDateString()}
+                        </p>
+                      </div>
+                    </div>
+                    
+                    <div className="flex items-center gap-2">
+                      {onOpenMessage && member.user_id !== userId && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button size="sm" variant="ghost" onClick={(e) => { e.stopPropagation(); onOpenMessage(member.username); }}>
+                                <Mail size={14} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Envoyer un message</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                      
+                      {/* Actions pour leader */}
+                      {selectedAlliance.user_role === 'leader' && member.user_id !== userId && (
+                        <>
+                          {member.role === 'member' && (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button size="sm" variant="ghost" onClick={() => handleChangeRole(member.user_id, 'officer')} className="text-blue-400">
+                                    <ChevronUp size={14} />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>Promouvoir officier</TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          )}
+                          {member.role === 'officer' && (
+                            <>
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button size="sm" variant="ghost" onClick={() => handleChangeRole(member.user_id, 'member')} className="text-slate-400">
+                                      <ChevronDown size={14} />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Rétrograder membre</TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button size="sm" variant="ghost" onClick={() => handleTransferLeadership(member.user_id)} className="text-yellow-400">
+                                      <Crown size={14} />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Transférer leadership</TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            </>
+                          )}
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button size="sm" variant="ghost" onClick={() => handleKickMember(member.user_id)} className="text-red-400">
+                                  <UserMinus size={14} />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>Expulser</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </>
+                      )}
+                      
+                      {/* Actions pour officier */}
+                      {selectedAlliance.user_role === 'officer' && member.role === 'member' && member.user_id !== userId && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button size="sm" variant="ghost" onClick={() => handleKickMember(member.user_id)} className="text-red-400">
+                                <UserMinus size={14} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Expulser</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Modal: Créer une alliance */}
+      <Dialog open={showCreateModal} onOpenChange={setShowCreateModal}>
+        <DialogContent className="bg-slate-900 border-white/10">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Plus size={20} /> Créer une alliance
+            </DialogTitle>
+            <DialogDescription>
+              Fondez votre propre alliance et recrutez des membres
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Nom de l'alliance (3-20 caractères)</label>
+              <Input
+                value={createForm.name}
+                onChange={e => setCreateForm(f => ({ ...f, name: e.target.value }))}
+                placeholder="Empire Galactique"
+                className="mt-1 bg-black/30 border-white/10"
+                maxLength={20}
+              />
+            </div>
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Tag (2-5 caractères)</label>
+              <Input
+                value={createForm.tag}
+                onChange={e => setCreateForm(f => ({ ...f, tag: e.target.value.toUpperCase() }))}
+                placeholder="EG"
+                className="mt-1 bg-black/30 border-white/10"
+                maxLength={5}
+              />
+              <p className="text-xs text-slate-500 mt-1">Affiché comme [{createForm.tag || 'TAG'}]</p>
+            </div>
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Description (optionnel)</label>
+              <Textarea
+                value={createForm.description}
+                onChange={e => setCreateForm(f => ({ ...f, description: e.target.value }))}
+                placeholder="Notre alliance conquiert la galaxie..."
+                className="mt-1 bg-black/30 border-white/10"
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowCreateModal(false)}>Annuler</Button>
+            <Button onClick={handleCreateAlliance} className="bg-gradient-to-r from-indigo-500 to-purple-600">
+              Créer l'alliance
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal: Inviter un joueur */}
+      <Dialog open={showInviteModal} onOpenChange={setShowInviteModal}>
+        <DialogContent className="bg-slate-900 border-white/10">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <UserPlus size={20} /> Inviter un joueur
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Nom du joueur</label>
+              <Input
+                value={inviteUsername}
+                onChange={e => setInviteUsername(e.target.value)}
+                placeholder="Pseudo exact du joueur"
+                className="mt-1 bg-black/30 border-white/10"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Message (optionnel)</label>
+              <Textarea
+                value={inviteMessage}
+                onChange={e => setInviteMessage(e.target.value)}
+                placeholder="Nous serions honorés de vous compter parmi nous..."
+                className="mt-1 bg-black/30 border-white/10"
+                rows={2}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowInviteModal(false)}>Annuler</Button>
+            <Button onClick={handleInvitePlayer} className="bg-gradient-to-r from-green-500 to-emerald-600">
+              Envoyer l'invitation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal: Postuler */}
+      <Dialog open={showApplyModal} onOpenChange={setShowApplyModal}>
+        <DialogContent className="bg-slate-900 border-white/10">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <UserPlus size={20} /> Postuler à [{selectedAlliance?.tag}] {selectedAlliance?.name}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Message de motivation (optionnel)</label>
+              <Textarea
+                value={applyMessage}
+                onChange={e => setApplyMessage(e.target.value)}
+                placeholder="Présentez-vous et expliquez pourquoi vous souhaitez rejoindre..."
+                className="mt-1 bg-black/30 border-white/10"
+                rows={4}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowApplyModal(false)}>Annuler</Button>
+            <Button onClick={() => selectedAlliance && handleApplyToAlliance(selectedAlliance.id)} className="bg-gradient-to-r from-green-500 to-emerald-600">
+              Envoyer ma candidature
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal: Paramètres */}
+      <Dialog open={showSettingsModal} onOpenChange={setShowSettingsModal}>
+        <DialogContent className="bg-slate-900 border-white/10">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Settings size={20} /> Paramètres de l'alliance
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Description</label>
+              <Textarea
+                value={settingsForm.description}
+                onChange={e => setSettingsForm(f => ({ ...f, description: e.target.value }))}
+                className="mt-1 bg-black/30 border-white/10"
+                rows={3}
+              />
+            </div>
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Message interne (visible par les membres)</label>
+              <Textarea
+                value={settingsForm.internal_message}
+                onChange={e => setSettingsForm(f => ({ ...f, internal_message: e.target.value }))}
+                className="mt-1 bg-black/30 border-white/10"
+                rows={3}
+              />
+            </div>
+            <div>
+              <label className="text-xs text-slate-400 uppercase">Politique de recrutement</label>
+              <select
+                value={settingsForm.recruitment_policy}
+                onChange={e => setSettingsForm(f => ({ ...f, recruitment_policy: e.target.value }))}
+                className="mt-1 w-full bg-black/30 border border-white/10 rounded-md p-2 text-white"
+              >
+                <option value="open">Ouvert (tout le monde peut rejoindre)</option>
+                <option value="invite_only">Sur invitation/candidature</option>
+                <option value="closed">Fermé (pas de nouveau membre)</option>
+              </select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowSettingsModal(false)}>Annuler</Button>
+            <Button onClick={handleUpdateSettings} className="bg-gradient-to-r from-indigo-500 to-purple-600">
+              Sauvegarder
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal: Confirmer quitter */}
+      <Dialog open={showConfirmLeave} onOpenChange={setShowConfirmLeave}>
+        <DialogContent className="bg-slate-900 border-red-500/30">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-red-400">
+              <LogOut size={20} /> Quitter l'alliance ?
+            </DialogTitle>
+            <DialogDescription>
+              Êtes-vous sûr de vouloir quitter [{selectedAlliance?.tag}] {selectedAlliance?.name} ?
+              Cette action est irréversible.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowConfirmLeave(false)}>Annuler</Button>
+            <Button onClick={handleLeaveAlliance} className="bg-red-500 hover:bg-red-600">
+              Quitter l'alliance
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal: Confirmer dissolution */}
+      <Dialog open={showConfirmDissolve} onOpenChange={setShowConfirmDissolve}>
+        <DialogContent className="bg-slate-900 border-red-500/30">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-red-400">
+              <Trash2 size={20} /> Dissoudre l'alliance ?
+            </DialogTitle>
+            <DialogDescription>
+              Êtes-vous sûr de vouloir DISSOUDRE [{selectedAlliance?.tag}] {selectedAlliance?.name} ?
+              <br /><br />
+              <strong className="text-red-400">ATTENTION:</strong> Tous les membres seront expulsés et l'alliance sera définitivement supprimée. Cette action est IRRÉVERSIBLE.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowConfirmDissolve(false)}>Annuler</Button>
+            <Button onClick={handleDissolveAlliance} className="bg-red-500 hover:bg-red-600">
+              Dissoudre définitivement
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default AllianceView;


### PR DESCRIPTION
Backend:
- Nouvelles entités: alliance, alliance_member, alliance_invitation
- Migration SQL pour les 3 tables avec index
- Module alliance.rs avec tous les handlers:
  * CRUD alliance (create, get, update, dissolve)
  * Gestion des membres (leave, kick, change_role, transfer_leadership)
  * Système d'invitations et candidatures
  * Calcul automatique du score d'alliance

Frontend:
- Composant AllianceView complet avec:
  * Liste et recherche d'alliances
  * Création d'alliance (nom, tag, description)
  * Vue détaillée avec membres et scores
  * Gestion des invitations/candidatures
  * Paramètres d'alliance (description, message interne, politique)
  * Actions: inviter, expulser, promouvoir/rétrograder
  * Transfert de leadership et dissolution

Fonctionnalités:
- 3 rôles: leader, officer, member
- 3 politiques: open, invite_only, closed
- Score d'alliance = somme des scores des membres
- Interface moderne avec modals et tooltips