### PR TITLE
fix(backend): Résoudre conflit de double compilation du crate

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod messaging;
 pub mod websocket;
 pub mod alliance;
+pub mod market;
 
 // Structures partagées - doivent être définies APRÈS entities mais AVANT admin
 use entities::{prelude::ServerConfig, server_config};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -33,18 +33,12 @@ use rand::Rng;
 
 use sea_orm_migration::MigratorTrait;
 
-mod auth;
-mod game_logic;
-mod combat;
-mod entities;
-mod config;
-mod admin;
-mod messaging;
-mod market;
-mod websocket;
-mod alliance;
+// Utiliser les modules de la lib pour éviter la double compilation
+use backend::{
+    auth, game_logic, combat, entities, config, admin, 
+    messaging, market, websocket, alliance, AppState
+};
 use config::Config;
-use backend::AppState;
 use websocket::WsState;
 
 // ✅ IMPORTS EXPLICITES


### PR DESCRIPTION
- Ajouter pub mod market à lib.rs
- Utiliser use backend::* dans main.rs au lieu de mod *
- Évite la double définition des types WsState, WsEvent, etc.