### PR TITLE
feat(sabotage): Complete sabotage system with UX improvements and Web…

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -284,6 +284,7 @@ async fn main() {
         .route("/sabotage", post(sabotage::attempt_sabotage))
         .route("/planets/:id/sabotages", get(sabotage::get_active_sabotages))
         .route("/sabotage/my-sabotages", get(sabotage::get_my_sabotages_handler))
+        .route("/sabotage/suffered", get(sabotage::get_sabotages_suffered_handler))
         .route("/casus-belli/active", get(sabotage::get_casus_belli_handler))
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/backend/src/sabotage.rs
+++ b/backend/src/sabotage.rs
@@ -103,6 +103,12 @@ pub async fn attempt_sabotage(
         }))).into_response();
     }
 
+    // Récupérer le nom d'utilisateur de l'attaquant pour les notifications
+    let attacker_user = match User::find_by_id(user_id).one(&state.db).await {
+        Ok(Some(u)) => u,
+        _ => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Utilisateur non trouvé"}))).into_response(),
+    };
+
     // Calculer la probabilité de détection
     // Base: 30%, -5% par niveau de différence (minimum 5%)
     let detection_chance = (30.0_f64 - (tech_difference as f64 * 5.0)).max(5.0_f64);
@@ -116,7 +122,25 @@ pub async fn attempt_sabotage(
             eprintln!("⚠️ Erreur lors de l'attribution du Casus Belli: {:?}", e);
         }
 
-        // TODO: Envoyer notification à la victime via WebSocket ou messaging system
+        // Notifier via WebSocket: sabotage détecté + casus belli accordé
+        if let Some(ref ws) = state.ws {
+            // 1. Notifier la victime que son système de défense a détecté un sabotage
+            crate::websocket::notify_sabotage_detected(
+                ws,
+                target_planet_id,
+                &attacker_user.username, // Nom de l'attaquant révélé car détecté
+                &target_planet.name,
+                &payload.action_type,
+            );
+
+            // 2. Notifier la victime qu'elle a obtenu un Casus Belli
+            crate::websocket::notify_casus_belli_granted(
+                ws,
+                target_planet.owner_id,
+                &attacker_user.username,
+                &reason,
+            ).await;
+        }
 
         return (StatusCode::OK, Json(SabotageResponse {
             success: false,
@@ -506,5 +530,73 @@ pub async fn get_casus_belli_handler(
 
     (StatusCode::OK, Json(json!({
         "casus_belli": casus_belli_with_info
+    }))).into_response()
+}
+
+/// Endpoint: Récupérer tous les sabotages subis (sur mes planètes)
+/// GET /sabotage/suffered
+pub async fn get_sabotages_suffered_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    // Vérifier l'authentification
+    let user_id = match extract_user_id_from_headers(&headers) {
+        Ok(id) => id,
+        Err(status) => return (status, Json(json!({"error": "Non authentifié"}))).into_response(),
+    };
+
+    // Récupérer toutes mes planètes
+    let my_planets = match Planet::find()
+        .filter(planet::Column::OwnerId.eq(user_id))
+        .all(&state.db)
+        .await
+    {
+        Ok(planets) => planets,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Erreur DB"}))).into_response(),
+    };
+
+    let planet_ids: Vec<String> = my_planets.iter().map(|p| p.id.clone()).collect();
+
+    // Récupérer tous les sabotages actifs et expirés sur mes planètes (historique complet)
+    let sabotages = match SabotageEffect::find()
+        .filter(sabotage_effect::Column::TargetPlanetId.is_in(planet_ids.clone()))
+        .order_by_desc(sabotage_effect::Column::CreatedAt)
+        .all(&state.db)
+        .await
+    {
+        Ok(s) => s,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Erreur DB"}))).into_response(),
+    };
+
+    // Pour chaque sabotage, récupérer les informations de l'attaquant et de la planète
+    use crate::entities::prelude::User;
+    let mut sabotages_with_info = Vec::new();
+
+    for sabotage in sabotages {
+        let planet = my_planets.iter().find(|p| p.id == sabotage.target_planet_id);
+        let attacker = match User::find_by_id(sabotage.attacker_user_id).one(&state.db).await {
+            Ok(Some(u)) => u,
+            _ => continue, // Utilisateur supprimé, skip
+        };
+
+        let now = Utc::now().naive_utc();
+        let is_active = sabotage.expires_at > now;
+
+        sabotages_with_info.push(json!({
+            "id": sabotage.id,
+            "attacker_user_id": sabotage.attacker_user_id,
+            "attacker_username": attacker.username,
+            "target_planet_id": sabotage.target_planet_id,
+            "target_planet_name": planet.map(|p| p.name.as_str()).unwrap_or("Planète inconnue"),
+            "effect_type": sabotage.effect_type,
+            "created_at": sabotage.created_at,
+            "expires_at": sabotage.expires_at,
+            "was_detected": sabotage.was_detected,
+            "is_active": is_active,
+        }));
+    }
+
+    (StatusCode::OK, Json(json!({
+        "sabotages": sabotages_with_info
     }))).into_response()
 }

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -126,6 +126,21 @@ pub enum WsEvent {
         from: String,
     },
 
+    /// Sabotage détecté sur ma planète
+    #[serde(rename = "sabotage_detected")]
+    SabotageDetected {
+        attacker_name: String,
+        planet_name: String,
+        effect_type: String, // "disable_mine" | "steal_tech"
+    },
+
+    /// Casus Belli accordé (droit d'attaque)
+    #[serde(rename = "casus_belli_granted")]
+    CasusBelliGranted {
+        target_name: String,
+        reason: String,
+    },
+
     /// Planète conquise ou perdue
     #[serde(rename = "planet_status")]
     PlanetStatus {
@@ -521,6 +536,23 @@ pub fn notify_spy_alert(state: &WsState, planet_id: Uuid, from: &str) {
     state.broadcast_to_planet(planet_id, WsEvent::SpyAlert {
         from: from.to_string(),
     });
+}
+
+/// Notifie qu'un sabotage a été détecté sur une planète
+pub fn notify_sabotage_detected(state: &WsState, planet_id: Uuid, attacker_name: &str, planet_name: &str, effect_type: &str) {
+    state.broadcast_to_planet(planet_id, WsEvent::SabotageDetected {
+        attacker_name: attacker_name.to_string(),
+        planet_name: planet_name.to_string(),
+        effect_type: effect_type.to_string(),
+    });
+}
+
+/// Notifie qu'un Casus Belli a été accordé à un utilisateur
+pub async fn notify_casus_belli_granted(state: &WsState, user_id: Uuid, target_name: &str, reason: &str) {
+    state.broadcast_to_user(user_id, WsEvent::CasusBelliGranted {
+        target_name: target_name.to_string(),
+        reason: reason.to_string(),
+    }).await;
 }
 
 /// Notifie un changement de statut de planète (conquise/perdue)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import AllianceView from './components/AllianceView';
 import MissionsView from './components/MissionsView';
 import Officers from './components/Officers';
 import { SabotagesDashboard } from './components/SabotagesDashboard';
+import { SabotagesSufferedDashboard } from './components/SabotagesSufferedDashboard';
 import { CasusBelliList } from './components/CasusBelliList';
 import { Sidebar, type MenuItem } from './components/Sidebar';
 import { FloatingResourceGain, useResourceGainAnimation } from './components/FloatingResourceGain';
@@ -41,7 +42,7 @@ import { Toaster, toast } from "sonner";
 import {
   LayoutDashboard, Pickaxe, Hammer,
   ShieldCheck, FlaskConical, Telescope, Trophy, ScrollText, Globe, Truck,
-  Settings as SettingsIcon, Mail, Factory, Rocket, X, Database, ShoppingCart, Keyboard, LogOut, MessageSquarePlus, FileText, Activity, Map, Shield, Users, Eye, Swords
+  Settings as SettingsIcon, Mail, Factory, Rocket, X, Database, ShoppingCart, Keyboard, LogOut, MessageSquarePlus, FileText, Activity, Map, Shield, Users, Eye, Swords, ShieldAlert
 } from "lucide-react";
 
 interface CombatReport {
@@ -76,6 +77,7 @@ export default function App() {
   const [transportTarget, setTransportTarget] = useState<{id: string, name: string, galaxy: number, system: number, position: number} | null>(null);
   const [spyReport, setSpyReport] = useState<any>(null);
   const [showSabotagesDashboard, setShowSabotagesDashboard] = useState(false);
+  const [showSabotagesSufferedDashboard, setShowSabotagesSufferedDashboard] = useState(false);
   const [showCasusBelliList, setShowCasusBelliList] = useState(false);
   const prevPlanetRef = useRef<any>(null);
   const processingReportRef = useRef(false);
@@ -579,6 +581,7 @@ export default function App() {
     { id: 'expedition', label: 'Expéditions', icon: Telescope, category: 'MILITAIRE' },
 
     { id: 'sabotages', label: 'Mes Sabotages', icon: Eye, category: 'ESPIONNAGE', onClick: () => setShowSabotagesDashboard(true) },
+    { id: 'sabotages-suffered', label: 'Sabotages Subis', icon: ShieldAlert, category: 'ESPIONNAGE', onClick: () => setShowSabotagesSufferedDashboard(true) },
     { id: 'casus-belli', label: 'Casus Belli', icon: Swords, category: 'ESPIONNAGE', onClick: () => setShowCasusBelliList(true) },
 
     { id: 'ranking', label: 'Classement', icon: Trophy, category: 'DONNÉES' },
@@ -639,6 +642,13 @@ export default function App() {
           <SabotagesDashboard
             token={token}
             onClose={() => setShowSabotagesDashboard(false)}
+          />
+        )}
+
+        {showSabotagesSufferedDashboard && token && (
+          <SabotagesSufferedDashboard
+            token={token}
+            onClose={() => setShowSabotagesSufferedDashboard(false)}
           />
         )}
 

--- a/frontend/src/components/CasusBelliList.tsx
+++ b/frontend/src/components/CasusBelliList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Card } from './ui/card';
-import { Swords, Clock, User } from 'lucide-react';
+import { Card, CardContent } from './ui/card';
+import { Swords, Clock, User, Target, AlertTriangle, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface CasusBelli {
@@ -62,117 +62,164 @@ export function CasusBelliList({ token, onClose }: CasusBelliListProps) {
     if (hours >= 24) {
       const days = Math.floor(hours / 24);
       const remainingHours = hours % 24;
-      return `${days}j ${remainingHours}h restantes`;
+      return `${days}j ${remainingHours}h`;
     }
     if (hours > 0) {
-      return `${hours}h ${minutes}min restantes`;
+      return `${hours}h ${minutes}min`;
     }
-    return `${minutes}min restantes`;
+    return `${minutes}min`;
   };
 
   if (loading) {
     return (
       <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
-        <Card className="bg-slate-900 border-indigo-500/30 p-6">
-          <p className="text-cyan-400 animate-pulse">Chargement...</p>
+        <Card className="bg-slate-950 border-red-500/30 p-6 card-depth">
+          <p className="text-cyan-400 animate-pulse font-mono text-sm">Chargement...</p>
         </Card>
       </div>
     );
   }
 
   return (
-    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <Card className="bg-slate-900 border-red-500/30 w-full max-w-4xl max-h-[90vh] overflow-auto">
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-in fade-in duration-300">
+      <Card className="bg-slate-950 border border-red-500/30 w-full max-w-5xl max-h-[90vh] overflow-hidden card-depth shadow-[0_0_50px_rgba(239,68,68,0.2)] animate-slide-up">
         {/* Header */}
-        <div className="border-b border-red-500/30 p-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Swords className="w-6 h-6 text-red-500" />
-              <h2 className="text-2xl font-bold text-red-400">Casus Belli - Droits d'Attaque</h2>
+        <div className="relative border-b border-red-500/30 p-6 bg-gradient-to-r from-red-950/50 to-orange-950/30 overflow-hidden">
+          <div className="absolute top-0 right-0 p-4 opacity-10">
+            <Swords size={120} className="animate-pulse" />
+          </div>
+
+          <div className="relative z-10 flex justify-between items-start">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="flex h-2 w-2 rounded-full bg-red-500 animate-pulse"></span>
+                <h3 className="font-mono text-[10px] uppercase tracking-[0.3em] text-red-400">Justice Militaire</h3>
+              </div>
+              <h2 className="text-3xl font-black uppercase tracking-wider text-white">Casus Belli</h2>
+              <p className="text-sm text-slate-400 mt-2 font-mono">
+                {casusBelli.length} droit{casusBelli.length !== 1 ? 's' : ''} d'attaque légitime disponible{casusBelli.length !== 1 ? 's' : ''}
+              </p>
             </div>
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-red-400 transition-colors text-2xl font-bold"
+              className="p-2 bg-white/5 hover:bg-white/10 rounded-full transition-all duration-300 hover:scale-110 card-depth hover:shadow-lg text-slate-400 hover:text-white"
             >
-              ×
+              <X size={20} />
             </button>
           </div>
-          <p className="text-slate-400 mt-2">
-            Vous avez {casusBelli.length} droit{casusBelli.length !== 1 ? 's' : ''} d'attaque légitime
-          </p>
         </div>
 
         {/* Body */}
-        <div className="p-6 space-y-4">
+        <div className="p-6 max-h-[calc(90vh-280px)] overflow-y-auto custom-scrollbar">
           {casusBelli.length === 0 ? (
-            <div className="text-center py-12">
-              <Swords className="w-16 h-16 text-slate-600 mx-auto mb-4" />
-              <p className="text-slate-400 text-lg">Aucun Casus Belli actif</p>
-              <p className="text-slate-500 text-sm mt-2">
+            <div className="text-center py-16">
+              <Swords className="w-20 h-20 text-slate-700 mx-auto mb-4 opacity-50" />
+              <p className="text-slate-400 text-lg font-bold uppercase tracking-wider">Aucun Casus Belli actif</p>
+              <p className="text-slate-600 text-sm mt-3 font-mono">
                 Les Casus Belli sont accordés quand vos ennemis sont pris en flagrant délit de sabotage.
               </p>
             </div>
           ) : (
             <>
-              <div className="bg-yellow-950/30 border border-yellow-600/50 rounded-lg p-4 mb-6">
-                <p className="text-yellow-300 text-sm">
-                  ⚔️ <strong>Casus Belli</strong> : Vous pouvez attaquer ces joueurs sans pénalité.
-                  Ces droits expirent après 48h ou après utilisation.
-                </p>
+              {/* Info Banner */}
+              <div className="bg-yellow-950/30 border border-yellow-500/30 rounded-lg p-4 mb-6 flex items-start gap-3">
+                <AlertTriangle size={20} className="text-yellow-400 shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-xs font-bold text-yellow-300 mb-1 uppercase tracking-wider">Droit de Représailles</p>
+                  <p className="text-[10px] text-yellow-200/80 leading-relaxed">
+                    Vous pouvez attaquer ces joueurs sans pénalité. Ces droits expirent après <span className="font-bold text-yellow-300">48 heures</span> ou après utilisation.
+                  </p>
+                </div>
               </div>
 
-              {casusBelli.map((cb) => (
-                <Card
-                  key={cb.id}
-                  className="p-4 border border-red-500/50 bg-gradient-to-br from-red-950/20 to-orange-950/20 hover:border-red-400/70 transition-colors"
-                >
-                  <div className="space-y-3">
-                    {/* Target */}
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <User className="w-5 h-5 text-red-400" />
-                        <span className="text-xl font-bold text-white">
-                          {cb.aggressor_username}
-                        </span>
-                        <span className="px-2 py-1 bg-red-600/30 border border-red-500 text-red-300 text-xs rounded uppercase font-bold">
-                          🎯 CIBLE LÉGALE
-                        </span>
-                      </div>
+              {/* Casus Belli Cards */}
+              <div className="space-y-4">
+                {casusBelli.map((cb) => (
+                  <Card
+                    key={cb.id}
+                    className="bg-black/40 border border-red-500/30 overflow-hidden relative hover:-translate-y-1 hover:shadow-2xl transition-all duration-500 card-depth shadow-[0_0_15px_rgba(239,68,68,0.1)]"
+                  >
+                    <div className="absolute top-0 right-0 p-2 opacity-5">
+                      <Target size={80} />
                     </div>
 
-                    {/* Reason */}
-                    <div className="bg-slate-800/50 rounded-lg p-3 border border-slate-700">
-                      <p className="text-sm text-slate-300">
-                        <span className="text-orange-400 font-semibold">Raison :</span> {cb.reason}
-                      </p>
-                    </div>
+                    <CardContent className="p-4 relative z-10">
+                      <div className="space-y-4">
+                        {/* Target Header */}
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <div className="p-2 rounded-full bg-red-500/20 border border-red-500/30 relative">
+                              <div className="absolute inset-0 rounded-full bg-red-500 animate-ping opacity-75"></div>
+                              <User className="w-5 h-5 text-red-400 relative z-10" />
+                            </div>
+                            <div>
+                              <span className="text-xl font-black text-white">
+                                {cb.aggressor_username}
+                              </span>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="px-2 py-0.5 bg-red-500/20 border border-red-500/30 text-red-300 text-[9px] rounded uppercase font-black tracking-wider">
+                                  🎯 Cible Légale
+                                </span>
+                              </div>
+                            </div>
+                          </div>
 
-                    {/* Time remaining */}
-                    <div className="flex items-center justify-between text-sm">
-                      <div className="flex items-center gap-2 text-slate-400">
-                        <Clock className="w-4 h-4" />
-                        <span>{getTimeRemaining(cb.expires_at)}</span>
+                          {/* Time Badge */}
+                          <div className="text-right">
+                            <div className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5">
+                              <div className="flex items-center gap-1.5 text-xs">
+                                <Clock className="w-3.5 h-3.5 text-slate-400" />
+                                <span className="font-mono text-white font-bold">
+                                  {getTimeRemaining(cb.expires_at)}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* Reason */}
+                        <div className="bg-slate-900/50 rounded-lg p-3 border border-white/5">
+                          <div className="flex items-start gap-2">
+                            <Swords className="w-4 h-4 text-orange-400 shrink-0 mt-0.5" />
+                            <div className="flex-1">
+                              <p className="text-[10px] font-bold text-orange-400 uppercase tracking-wider mb-1">
+                                Motif du Casus Belli
+                              </p>
+                              <p className="text-sm text-slate-300 leading-relaxed">
+                                {cb.reason}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* Status Bar */}
+                        <div className="flex items-center justify-between p-3 bg-emerald-950/20 border border-emerald-500/30 rounded-lg">
+                          <div className="flex items-center gap-2">
+                            <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></div>
+                            <span className="text-xs font-bold text-emerald-400 uppercase tracking-wider">
+                              Attaque autorisée sans pénalité
+                            </span>
+                          </div>
+                          <Swords className="w-4 h-4 text-emerald-400" />
+                        </div>
                       </div>
-                      <div className="text-emerald-400 font-semibold">
-                        ✓ Attaque autorisée
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              ))}
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             </>
           )}
         </div>
 
         {/* Footer */}
-        <div className="border-t border-red-500/30 p-6 space-y-3">
-          <div className="bg-slate-800/50 rounded-lg p-3 text-sm text-slate-400">
-            💡 <strong>Astuce :</strong> Les Casus Belli vous permettent d'attaquer sans risque de pénalité.
+        <div className="border-t border-red-500/30 p-4 bg-slate-900/50">
+          <div className="bg-slate-800/50 rounded-lg p-3 text-xs text-slate-400 mb-3 border border-white/5">
+            <span className="text-slate-300 font-bold">💡 Astuce :</span> Les Casus Belli vous permettent d'attaquer sans risque de pénalité.
             Utilisez-les stratégiquement avant qu'ils n'expirent !
           </div>
           <button
             onClick={onClose}
-            className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 uppercase tracking-widest text-sm card-depth hover:-translate-y-1 hover:shadow-lg"
           >
             Fermer
           </button>

--- a/frontend/src/components/SabotagesDashboard.tsx
+++ b/frontend/src/components/SabotagesDashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Card } from './ui/card';
-import { Shield, Clock, Target } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Shield, Clock, Target, Eye, TrendingDown, Zap, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface Sabotage {
@@ -60,15 +60,26 @@ export function SabotagesDashboard({ token, onClose }: SabotagesDashboardProps) 
     const hours = Math.floor(diff / (1000 * 60 * 60));
     const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
 
-    if (hours > 0) {
-      return `${hours}h ${minutes}min restantes`;
+    if (hours >= 24) {
+      const days = Math.floor(hours / 24);
+      const remainingHours = hours % 24;
+      return `${days}j ${remainingHours}h`;
     }
-    return `${minutes}min restantes`;
+    if (hours > 0) {
+      return `${hours}h ${minutes}min`;
+    }
+    return `${minutes}min`;
+  };
+
+  const getEffectIcon = (type: string) => {
+    if (type === 'disable_mine') return TrendingDown;
+    if (type === 'steal_tech') return Eye;
+    return Zap;
   };
 
   const getEffectLabel = (type: string) => {
-    if (type === 'disable_mine') return '⚙️ Mine Désactivée';
-    if (type === 'steal_tech') return '📖 Technologie Volée';
+    if (type === 'disable_mine') return 'Infrastructure Sabotée';
+    if (type === 'steal_tech') return 'Espionnage Industriel';
     return type;
   };
 
@@ -81,108 +92,194 @@ export function SabotagesDashboard({ token, onClose }: SabotagesDashboardProps) 
   if (loading) {
     return (
       <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
-        <Card className="bg-slate-900 border-indigo-500/30 p-6">
-          <p className="text-cyan-400 animate-pulse">Chargement...</p>
+        <Card className="bg-slate-950 border-indigo-500/30 p-6 card-depth">
+          <p className="text-cyan-400 animate-pulse font-mono text-sm">Chargement...</p>
         </Card>
       </div>
     );
   }
 
+  const successfulSabotages = sabotages.filter(s => !s.was_detected);
+  const detectedSabotages = sabotages.filter(s => s.was_detected);
+
   return (
-    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <Card className="bg-slate-900 border-indigo-500/30 w-full max-w-4xl max-h-[90vh] overflow-auto">
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-in fade-in duration-300">
+      <Card className="bg-slate-950 border border-indigo-500/30 w-full max-w-5xl max-h-[90vh] overflow-hidden card-depth shadow-[0_0_50px_rgba(99,102,241,0.2)] animate-slide-up">
         {/* Header */}
-        <div className="border-b border-indigo-500/30 p-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Shield className="w-6 h-6 text-red-500" />
-              <h2 className="text-2xl font-bold text-indigo-400">Mes Sabotages Actifs</h2>
+        <div className="relative border-b border-indigo-500/30 p-6 bg-gradient-to-r from-indigo-950/50 to-purple-950/30 overflow-hidden">
+          <div className="absolute top-0 right-0 p-4 opacity-10">
+            <Shield size={120} className="animate-pulse" />
+          </div>
+
+          <div className="relative z-10 flex justify-between items-start">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="flex h-2 w-2 rounded-full bg-indigo-500 animate-pulse"></span>
+                <h3 className="font-mono text-[10px] uppercase tracking-[0.3em] text-indigo-400">Opérations Clandestines</h3>
+              </div>
+              <h2 className="text-3xl font-black uppercase tracking-wider text-white">Mes Sabotages</h2>
+              <p className="text-sm text-slate-400 mt-2 font-mono">
+                {sabotages.length} opération{sabotages.length !== 1 ? 's' : ''} active{sabotages.length !== 1 ? 's' : ''} •
+                <span className="text-emerald-400 ml-2">{successfulSabotages.length} réussie{successfulSabotages.length !== 1 ? 's' : ''}</span> •
+                <span className="text-red-400 ml-2">{detectedSabotages.length} détectée{detectedSabotages.length !== 1 ? 's' : ''}</span>
+              </p>
             </div>
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-red-400 transition-colors text-2xl font-bold"
+              className="p-2 bg-white/5 hover:bg-white/10 rounded-full transition-all duration-300 hover:scale-110 card-depth hover:shadow-lg text-slate-400 hover:text-white"
             >
-              ×
+              <X size={20} />
             </button>
           </div>
-          <p className="text-slate-400 mt-2">
-            {sabotages.length} sabotage{sabotages.length !== 1 ? 's' : ''} en cours
-          </p>
         </div>
 
         {/* Body */}
-        <div className="p-6 space-y-4">
+        <div className="p-6 max-h-[calc(90vh-200px)] overflow-y-auto custom-scrollbar">
           {sabotages.length === 0 ? (
-            <div className="text-center py-12">
-              <Shield className="w-16 h-16 text-slate-600 mx-auto mb-4" />
-              <p className="text-slate-400 text-lg">Aucun sabotage actif</p>
-              <p className="text-slate-500 text-sm mt-2">
+            <div className="text-center py-16">
+              <Shield className="w-20 h-20 text-slate-700 mx-auto mb-4 opacity-50" />
+              <p className="text-slate-400 text-lg font-bold uppercase tracking-wider">Aucun sabotage actif</p>
+              <p className="text-slate-600 text-sm mt-3 font-mono">
                 Effectuez un espionnage puis sabotez vos ennemis !
               </p>
             </div>
           ) : (
-            sabotages.map((sabotage) => (
-              <Card
-                key={sabotage.id}
-                className={`p-4 border ${
-                  sabotage.was_detected
-                    ? 'border-red-500/50 bg-red-950/20'
-                    : 'border-emerald-500/50 bg-emerald-950/20'
-                }`}
-              >
-                <div className="flex items-start justify-between gap-4">
-                  {/* Left side - Info */}
-                  <div className="flex-1 space-y-2">
-                    <div className="flex items-center gap-3">
-                      <Target className="w-5 h-5 text-orange-400" />
-                      <span className="text-lg font-bold text-white">
-                        {sabotage.target_planet_name}
-                      </span>
-                      {sabotage.was_detected && (
-                        <span className="px-2 py-1 bg-red-600/20 border border-red-500 text-red-400 text-xs rounded uppercase font-bold">
-                          🚨 Détecté
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                      <span className="text-indigo-300 font-semibold">
-                        {getEffectLabel(sabotage.effect_type)}
-                      </span>
-                      <span className="text-slate-400 text-sm">
-                        • {getEffectDescription(sabotage.effect_type)}
-                      </span>
-                    </div>
-
-                    <div className="flex items-center gap-2 text-sm text-slate-400">
-                      <Clock className="w-4 h-4" />
-                      <span>{getTimeRemaining(sabotage.expires_at)}</span>
-                    </div>
+            <div className="space-y-4">
+              {/* Successful Sabotages */}
+              {successfulSabotages.length > 0 && (
+                <>
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-emerald-500/30 to-transparent"></div>
+                    <span className="text-[10px] font-black uppercase tracking-[0.3em] text-emerald-400">Opérations Réussies</span>
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-emerald-500/30 to-transparent"></div>
                   </div>
 
-                  {/* Right side - Status */}
-                  <div className="text-right">
-                    <div
-                      className={`px-3 py-1 rounded-full text-sm font-bold ${
-                        sabotage.was_detected
-                          ? 'bg-red-500/20 text-red-400'
-                          : 'bg-emerald-500/20 text-emerald-400'
-                      }`}
-                    >
-                      {sabotage.was_detected ? 'ÉCHEC' : 'SUCCÈS'}
-                    </div>
+                  {successfulSabotages.map((sabotage) => {
+                    const EffectIcon = getEffectIcon(sabotage.effect_type);
+                    return (
+                      <Card
+                        key={sabotage.id}
+                        className="bg-black/40 border border-emerald-500/30 overflow-hidden relative hover:-translate-y-1 hover:shadow-2xl transition-all duration-500 card-depth shadow-[0_0_15px_rgba(16,185,129,0.1)]"
+                      >
+                        <div className="absolute top-0 right-0 p-2 opacity-5">
+                          <EffectIcon size={60} />
+                        </div>
+                        <CardContent className="p-4 relative z-10">
+                          <div className="flex items-start justify-between gap-4">
+                            {/* Left side - Info */}
+                            <div className="flex-1 space-y-3">
+                              <div className="flex items-center gap-3">
+                                <div className="p-2 rounded-full bg-emerald-500/20 border border-emerald-500/30">
+                                  <Target className="w-5 h-5 text-emerald-400" />
+                                </div>
+                                <div>
+                                  <span className="text-base font-bold text-white">
+                                    {sabotage.target_planet_name}
+                                  </span>
+                                  <div className="flex items-center gap-2 mt-1">
+                                    <span className="px-2 py-0.5 bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 text-[9px] rounded uppercase font-black tracking-wider">
+                                      ✓ Succès
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center gap-2 bg-slate-900/50 rounded-lg p-2 border border-white/5">
+                                <EffectIcon className="w-4 h-4 text-emerald-400" />
+                                <span className="text-xs font-bold text-emerald-300">
+                                  {getEffectLabel(sabotage.effect_type)}
+                                </span>
+                                <span className="text-[10px] text-slate-400">
+                                  • {getEffectDescription(sabotage.effect_type)}
+                                </span>
+                              </div>
+
+                              <div className="flex items-center gap-2 text-xs text-slate-400">
+                                <Clock className="w-3.5 h-3.5" />
+                                <span className="font-mono">{getTimeRemaining(sabotage.expires_at)} restantes</span>
+                              </div>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </>
+              )}
+
+              {/* Detected Sabotages */}
+              {detectedSabotages.length > 0 && (
+                <>
+                  <div className="flex items-center gap-2 mb-3 mt-6">
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-red-500/30 to-transparent"></div>
+                    <span className="text-[10px] font-black uppercase tracking-[0.3em] text-red-400">Opérations Détectées</span>
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-red-500/30 to-transparent"></div>
                   </div>
-                </div>
-              </Card>
-            ))
+
+                  {detectedSabotages.map((sabotage) => {
+                    const EffectIcon = getEffectIcon(sabotage.effect_type);
+                    return (
+                      <Card
+                        key={sabotage.id}
+                        className="bg-black/40 border border-red-500/30 overflow-hidden relative hover:-translate-y-1 hover:shadow-2xl transition-all duration-500 card-depth shadow-[0_0_15px_rgba(239,68,68,0.1)]"
+                      >
+                        <div className="absolute top-0 right-0 p-2 opacity-5">
+                          <EffectIcon size={60} />
+                        </div>
+                        <CardContent className="p-4 relative z-10">
+                          <div className="flex items-start justify-between gap-4">
+                            {/* Left side - Info */}
+                            <div className="flex-1 space-y-3">
+                              <div className="flex items-center gap-3">
+                                <div className="p-2 rounded-full bg-red-500/20 border border-red-500/30 relative">
+                                  <div className="absolute inset-0 rounded-full bg-red-500 animate-ping opacity-75"></div>
+                                  <Target className="w-5 h-5 text-red-400 relative z-10" />
+                                </div>
+                                <div>
+                                  <span className="text-base font-bold text-white">
+                                    {sabotage.target_planet_name}
+                                  </span>
+                                  <div className="flex items-center gap-2 mt-1">
+                                    <span className="px-2 py-0.5 bg-red-500/20 border border-red-500/30 text-red-300 text-[9px] rounded uppercase font-black tracking-wider animate-pulse">
+                                      🚨 Détecté
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center gap-2 bg-red-950/30 rounded-lg p-2 border border-red-500/20">
+                                <EffectIcon className="w-4 h-4 text-red-400" />
+                                <span className="text-xs font-bold text-red-300">
+                                  {getEffectLabel(sabotage.effect_type)}
+                                </span>
+                                <span className="text-[10px] text-slate-400">
+                                  • Opération compromise
+                                </span>
+                              </div>
+
+                              <div className="bg-yellow-950/30 border border-yellow-500/30 rounded-lg p-2 flex items-start gap-2">
+                                <Zap size={14} className="text-yellow-400 shrink-0 mt-0.5" />
+                                <p className="text-[10px] text-yellow-200/80 leading-relaxed">
+                                  <span className="font-bold text-yellow-300">Casus Belli accordé</span> — La cible peut vous attaquer sans pénalité pendant 48h
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </>
+              )}
+            </div>
           )}
         </div>
 
         {/* Footer */}
-        <div className="border-t border-indigo-500/30 p-6">
+        <div className="border-t border-indigo-500/30 p-4 bg-slate-900/50">
           <button
             onClick={onClose}
-            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 uppercase tracking-widest text-sm card-depth hover:-translate-y-1 hover:shadow-lg"
           >
             Fermer
           </button>

--- a/frontend/src/components/SabotagesSufferedDashboard.tsx
+++ b/frontend/src/components/SabotagesSufferedDashboard.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent } from './ui/card';
+import { ShieldAlert, Clock, User, Eye, TrendingDown, Zap, X, AlertCircle, CheckCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface SabotageSuffered {
+  id: string;
+  attacker_user_id: string;
+  attacker_username: string;
+  target_planet_id: string;
+  target_planet_name: string;
+  effect_type: 'disable_mine' | 'steal_tech';
+  created_at: string;
+  expires_at: string;
+  was_detected: boolean;
+  is_active: boolean;
+}
+
+interface SabotagesSufferedDashboardProps {
+  token: string;
+  onClose: () => void;
+}
+
+export function SabotagesSufferedDashboard({ token, onClose }: SabotagesSufferedDashboardProps) {
+  const [sabotages, setSabotages] = useState<SabotageSuffered[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'all' | 'active' | 'expired'>('active');
+
+  const apiUrl = (path: string) => `http://localhost:8080${path}`;
+
+  useEffect(() => {
+    fetchSabotages();
+  }, []);
+
+  const fetchSabotages = async () => {
+    try {
+      const res = await fetch(apiUrl('/sabotage/suffered'), {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setSabotages(data.sabotages || []);
+      } else {
+        toast.error('Erreur lors du chargement des sabotages');
+      }
+    } catch (e) {
+      toast.error('Erreur réseau');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getTimeRemaining = (expiresAt: string) => {
+    const now = new Date().getTime();
+    const expiry = new Date(expiresAt).getTime();
+    const diff = expiry - now;
+
+    if (diff <= 0) return 'Expiré';
+
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+    if (hours >= 24) {
+      const days = Math.floor(hours / 24);
+      const remainingHours = hours % 24;
+      return `${days}j ${remainingHours}h`;
+    }
+    if (hours > 0) {
+      return `${hours}h ${minutes}min`;
+    }
+    return `${minutes}min`;
+  };
+
+  const getEffectIcon = (type: string) => {
+    if (type === 'disable_mine') return TrendingDown;
+    if (type === 'steal_tech') return Eye;
+    return Zap;
+  };
+
+  const getEffectLabel = (type: string) => {
+    if (type === 'disable_mine') return 'Infrastructure Sabotée';
+    if (type === 'steal_tech') return 'Espionnage Industriel';
+    return type;
+  };
+
+  const getEffectDescription = (type: string) => {
+    if (type === 'disable_mine') return 'Production -50% pendant 1h';
+    if (type === 'steal_tech') return 'Bonus recherche -20% (7 jours)';
+    return '';
+  };
+
+  if (loading) {
+    return (
+      <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
+        <Card className="bg-slate-950 border-orange-500/30 p-6 card-depth">
+          <p className="text-cyan-400 animate-pulse font-mono text-sm">Chargement...</p>
+        </Card>
+      </div>
+    );
+  }
+
+  // Filter sabotages
+  const filteredSabotages = sabotages.filter(s => {
+    if (filter === 'active') return s.is_active;
+    if (filter === 'expired') return !s.is_active;
+    return true;
+  });
+
+  const detectedSabotages = filteredSabotages.filter(s => s.was_detected);
+  const undetectedSabotages = filteredSabotages.filter(s => !s.was_detected);
+
+  // Stats
+  const totalSabotages = sabotages.length;
+  const activeSabotages = sabotages.filter(s => s.is_active).length;
+  const detectedCount = sabotages.filter(s => s.was_detected).length;
+  const detectionRate = totalSabotages > 0 ? Math.round((detectedCount / totalSabotages) * 100) : 0;
+
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-in fade-in duration-300">
+      <Card className="bg-slate-950 border border-orange-500/30 w-full max-w-6xl max-h-[90vh] overflow-hidden card-depth shadow-[0_0_50px_rgba(249,115,22,0.2)] animate-slide-up">
+        {/* Header */}
+        <div className="relative border-b border-orange-500/30 p-6 bg-gradient-to-r from-orange-950/50 to-red-950/30 overflow-hidden">
+          <div className="absolute top-0 right-0 p-4 opacity-10">
+            <ShieldAlert size={120} className="animate-pulse" />
+          </div>
+
+          <div className="relative z-10 flex justify-between items-start">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="flex h-2 w-2 rounded-full bg-orange-500 animate-pulse"></span>
+                <h3 className="font-mono text-[10px] uppercase tracking-[0.3em] text-orange-400">Sécurité Planétaire</h3>
+              </div>
+              <h2 className="text-3xl font-black uppercase tracking-wider text-white">Sabotages Subis</h2>
+              <p className="text-sm text-slate-400 mt-2 font-mono">
+                {totalSabotages} tentative{totalSabotages !== 1 ? 's' : ''} totale{totalSabotages !== 1 ? 's' : ''} •
+                <span className="text-red-400 ml-2">{activeSabotages} actif{activeSabotages !== 1 ? 's' : ''}</span> •
+                <span className="text-emerald-400 ml-2">{detectionRate}% détectés</span>
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 bg-white/5 hover:bg-white/10 rounded-full transition-all duration-300 hover:scale-110 card-depth hover:shadow-lg text-slate-400 hover:text-white"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Filter Tabs */}
+        <div className="border-b border-white/5 px-6 pt-4 pb-0 bg-slate-900/30">
+          <div className="flex gap-2">
+            {[
+              { id: 'active', label: 'Actifs', count: sabotages.filter(s => s.is_active).length },
+              { id: 'expired', label: 'Expirés', count: sabotages.filter(s => !s.is_active).length },
+              { id: 'all', label: 'Tous', count: sabotages.length },
+            ].map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setFilter(tab.id as any)}
+                className={`px-4 py-2 text-xs font-bold uppercase tracking-wider transition-all duration-300 border-b-2 ${
+                  filter === tab.id
+                    ? 'border-orange-500 text-orange-400'
+                    : 'border-transparent text-slate-500 hover:text-slate-300'
+                }`}
+              >
+                {tab.label} ({tab.count})
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 max-h-[calc(90vh-280px)] overflow-y-auto custom-scrollbar">
+          {filteredSabotages.length === 0 ? (
+            <div className="text-center py-16">
+              <ShieldAlert className="w-20 h-20 text-slate-700 mx-auto mb-4 opacity-50" />
+              <p className="text-slate-400 text-lg font-bold uppercase tracking-wider">
+                {filter === 'active' ? 'Aucun sabotage actif' : filter === 'expired' ? 'Aucun sabotage expiré' : 'Aucun sabotage'}
+              </p>
+              <p className="text-slate-600 text-sm mt-3 font-mono">
+                {totalSabotages === 0 ? 'Vos défenses sont intactes !' : 'Filtrez pour voir d\'autres sabotages'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {/* Detected Sabotages (Casus Belli granted) */}
+              {detectedSabotages.length > 0 && (
+                <>
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-emerald-500/30 to-transparent"></div>
+                    <span className="text-[10px] font-black uppercase tracking-[0.3em] text-emerald-400">
+                      Saboteurs Détectés ({detectedSabotages.length})
+                    </span>
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-emerald-500/30 to-transparent"></div>
+                  </div>
+
+                  <div className="space-y-4">
+                    {detectedSabotages.map((sabotage) => {
+                      const EffectIcon = getEffectIcon(sabotage.effect_type);
+                      return (
+                        <Card
+                          key={sabotage.id}
+                          className="bg-black/40 border border-emerald-500/30 overflow-hidden relative hover:-translate-y-1 hover:shadow-2xl transition-all duration-500 card-depth shadow-[0_0_15px_rgba(16,185,129,0.1)]"
+                        >
+                          <div className="absolute top-0 right-0 p-2 opacity-5">
+                            <CheckCircle size={60} />
+                          </div>
+                          <CardContent className="p-4 relative z-10">
+                            <div className="space-y-3">
+                              {/* Header */}
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3">
+                                  <div className="p-2 rounded-full bg-emerald-500/20 border border-emerald-500/30">
+                                    <User className="w-5 h-5 text-emerald-400" />
+                                  </div>
+                                  <div>
+                                    <span className="text-base font-bold text-white">
+                                      {sabotage.attacker_username}
+                                    </span>
+                                    <div className="flex items-center gap-2 mt-1">
+                                      <span className="px-2 py-0.5 bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 text-[9px] rounded uppercase font-black tracking-wider">
+                                        ✓ Détecté
+                                      </span>
+                                      <span className="text-[9px] text-slate-500 font-mono">
+                                        • {sabotage.target_planet_name}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div className="text-right">
+                                  <div className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5">
+                                    <div className="flex items-center gap-1.5 text-xs">
+                                      <Clock className="w-3.5 h-3.5 text-slate-400" />
+                                      <span className="font-mono text-white font-bold">
+                                        {sabotage.is_active ? getTimeRemaining(sabotage.expires_at) : 'Expiré'}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+
+                              {/* Effect */}
+                              <div className="flex items-center gap-2 bg-slate-900/50 rounded-lg p-2 border border-white/5">
+                                <EffectIcon className="w-4 h-4 text-orange-400" />
+                                <span className="text-xs font-bold text-orange-300">
+                                  {getEffectLabel(sabotage.effect_type)}
+                                </span>
+                                <span className="text-[10px] text-slate-400">
+                                  • {getEffectDescription(sabotage.effect_type)}
+                                </span>
+                              </div>
+
+                              {/* Casus Belli Notice */}
+                              <div className="bg-yellow-950/30 border border-yellow-500/30 rounded-lg p-2 flex items-start gap-2">
+                                <Zap size={14} className="text-yellow-400 shrink-0 mt-0.5" />
+                                <p className="text-[10px] text-yellow-200/80 leading-relaxed">
+                                  <span className="font-bold text-yellow-300">Casus Belli accordé</span> — Vous pouvez attaquer ce joueur sans pénalité
+                                </p>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+
+              {/* Undetected Sabotages (Still suffering) */}
+              {undetectedSabotages.length > 0 && (
+                <>
+                  <div className="flex items-center gap-2 mb-3 mt-6">
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-red-500/30 to-transparent"></div>
+                    <span className="text-[10px] font-black uppercase tracking-[0.3em] text-red-400">
+                      Sabotages Non Détectés ({undetectedSabotages.length})
+                    </span>
+                    <div className="h-px flex-1 bg-gradient-to-r from-transparent via-red-500/30 to-transparent"></div>
+                  </div>
+
+                  <div className="space-y-4">
+                    {undetectedSabotages.map((sabotage) => {
+                      const EffectIcon = getEffectIcon(sabotage.effect_type);
+                      return (
+                        <Card
+                          key={sabotage.id}
+                          className="bg-black/40 border border-red-500/30 overflow-hidden relative hover:-translate-y-1 hover:shadow-2xl transition-all duration-500 card-depth shadow-[0_0_15px_rgba(239,68,68,0.1)]"
+                        >
+                          <div className="absolute top-0 right-0 p-2 opacity-5">
+                            <AlertCircle size={60} />
+                          </div>
+                          <CardContent className="p-4 relative z-10">
+                            <div className="space-y-3">
+                              {/* Header */}
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3">
+                                  <div className="p-2 rounded-full bg-red-500/20 border border-red-500/30 relative">
+                                    <div className="absolute inset-0 rounded-full bg-red-500 animate-ping opacity-75"></div>
+                                    <User className="w-5 h-5 text-red-400 relative z-10" />
+                                  </div>
+                                  <div>
+                                    <span className="text-base font-bold text-slate-400">
+                                      Saboteur Inconnu
+                                    </span>
+                                    <div className="flex items-center gap-2 mt-1">
+                                      <span className="px-2 py-0.5 bg-red-500/20 border border-red-500/30 text-red-300 text-[9px] rounded uppercase font-black tracking-wider">
+                                        ⚠ Infiltré
+                                      </span>
+                                      <span className="text-[9px] text-slate-500 font-mono">
+                                        • {sabotage.target_planet_name}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div className="text-right">
+                                  <div className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5">
+                                    <div className="flex items-center gap-1.5 text-xs">
+                                      <Clock className="w-3.5 h-3.5 text-slate-400" />
+                                      <span className="font-mono text-white font-bold">
+                                        {sabotage.is_active ? getTimeRemaining(sabotage.expires_at) : 'Expiré'}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+
+                              {/* Effect */}
+                              <div className="flex items-center gap-2 bg-red-950/30 rounded-lg p-2 border border-red-500/20">
+                                <EffectIcon className="w-4 h-4 text-red-400" />
+                                <span className="text-xs font-bold text-red-300">
+                                  {getEffectLabel(sabotage.effect_type)}
+                                </span>
+                                <span className="text-[10px] text-slate-400">
+                                  • {getEffectDescription(sabotage.effect_type)}
+                                </span>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-orange-500/30 p-4 bg-slate-900/50">
+          <div className="bg-slate-800/50 rounded-lg p-3 text-xs text-slate-400 mb-3 border border-white/5">
+            <span className="text-slate-300 font-bold">💡 Conseil :</span> Améliorez votre niveau d'espionnage pour augmenter vos chances de détecter les saboteurs et obtenir des Casus Belli !
+          </div>
+          <button
+            onClick={onClose}
+            className="w-full bg-orange-600 hover:bg-orange-700 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 uppercase tracking-widest text-sm card-depth hover:-translate-y-1 hover:shadow-lg"
+          >
+            Fermer
+          </button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/SpyModal.tsx
+++ b/frontend/src/components/SpyModal.tsx
@@ -113,64 +113,81 @@ export default function SpyModal({ report, onClose, targetPlanetId, onSabotage }
                 ) : null}
             </Section>
 
-            {/* 4. ACTIONS DE SABOTAGE (si espionnage réussi) */}
-            {report.success && report.tech_difference >= 1 && onSabotage && (
+            {/* 4. ACTIONS DE SABOTAGE */}
+            {report.success && onSabotage && (
                 <>
                     <Separator className="bg-white/5" />
-                    <Section title="Opérations Clandestines" icon={Zap} isLocked={false} delay={4}>
-                        <div className="space-y-3">
-                            {/* Avertissement */}
-                            <div className="bg-yellow-950/20 border border-yellow-500/30 rounded-lg p-3 flex items-start gap-3">
-                                <AlertTriangle size={20} className="text-yellow-400 shrink-0 mt-0.5" />
+                    {report.tech_difference >= 1 ? (
+                        <Section title="Opérations Clandestines" icon={Zap} isLocked={false} delay={4}>
+                            <div className="space-y-3">
+                                {/* Avertissement */}
+                                <div className="bg-yellow-950/20 border border-yellow-500/30 rounded-lg p-3 flex items-start gap-3">
+                                    <AlertTriangle size={20} className="text-yellow-400 shrink-0 mt-0.5" />
+                                    <div>
+                                        <div className="text-xs font-bold text-yellow-300 mb-1">Risques Opérationnels</div>
+                                        <div className="text-[10px] text-yellow-200/70 leading-relaxed">
+                                            Si détecté: sonde détruite + Casus Belli (droit d'attaque sans pénalité)
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Option 1: Désactiver mine */}
+                                <button
+                                    onClick={() => onSabotage('disable_mine')}
+                                    className="w-full bg-orange-950/30 border border-orange-500/30 rounded-lg p-3 hover:bg-orange-950/50 transition-all duration-300 group card-depth hover:-translate-y-1 hover:shadow-lg"
+                                >
+                                    <div className="flex items-start gap-3">
+                                        <TrendingDown size={20} className="text-orange-400 shrink-0 group-hover:animate-bounce" />
+                                        <div className="text-left flex-1">
+                                            <div className="text-xs font-bold text-orange-300 mb-1">Saboter Infrastructure</div>
+                                            <div className="text-[10px] text-orange-200/70 leading-relaxed">
+                                                Désactive temporairement une mine (-50% prod pendant 1h)
+                                            </div>
+                                            <div className="flex items-center gap-2 mt-2 text-[9px] text-orange-400/80">
+                                                <Clock size={10} />
+                                                <span>Durée: 1 heure</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </button>
+
+                                {/* Option 2: Voler tech */}
+                                <button
+                                    onClick={() => onSabotage('steal_tech')}
+                                    className="w-full bg-purple-950/30 border border-purple-500/30 rounded-lg p-3 hover:bg-purple-950/50 transition-all duration-300 group card-depth hover:-translate-y-1 hover:shadow-lg"
+                                >
+                                    <div className="flex items-start gap-3">
+                                        <Eye size={20} className="text-purple-400 shrink-0 group-hover:animate-pulse" />
+                                        <div className="text-left flex-1">
+                                            <div className="text-xs font-bold text-purple-300 mb-1">Espionnage Industriel</div>
+                                            <div className="text-[10px] text-purple-200/70 leading-relaxed">
+                                                Vole des données techniques (-20% temps recherche suivante)
+                                            </div>
+                                            <div className="flex items-center gap-2 mt-2 text-[9px] text-purple-400/80">
+                                                <Skull size={10} />
+                                                <span>Risque: Élevé</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </button>
+                            </div>
+                        </Section>
+                    ) : (
+                        <Section title="Opérations Clandestines" icon={Zap} isLocked={true} delay={4}>
+                            <div className="bg-red-950/20 border border-red-500/30 rounded-lg p-3 flex items-start gap-3">
+                                <Lock size={20} className="text-red-400 shrink-0 mt-0.5" />
                                 <div>
-                                    <div className="text-xs font-bold text-yellow-300 mb-1">Risques Opérationnels</div>
-                                    <div className="text-[10px] text-yellow-200/70 leading-relaxed">
-                                        Si détecté: sonde détruite + Casus Belli (droit d'attaque sans pénalité)
+                                    <div className="text-xs font-bold text-red-300 mb-1">Avantage Technologique Insuffisant</div>
+                                    <div className="text-[10px] text-red-200/70 leading-relaxed">
+                                        Votre niveau d'espionnage doit être supérieur d'au moins <span className="font-bold text-red-300">1 niveau</span> à la cible pour effectuer des sabotages.
+                                    </div>
+                                    <div className="mt-2 text-[10px] text-slate-400">
+                                        Delta Tech actuel: <span className={report.tech_difference >= 0 ? "text-amber-400" : "text-red-400"}>{report.tech_difference}</span> (minimum requis: +1)
                                     </div>
                                 </div>
                             </div>
-
-                            {/* Option 1: Désactiver mine */}
-                            <button
-                                onClick={() => onSabotage('disable_mine')}
-                                className="w-full bg-orange-950/30 border border-orange-500/30 rounded-lg p-3 hover:bg-orange-950/50 transition-all duration-300 group card-depth hover:-translate-y-1 hover:shadow-lg"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <TrendingDown size={20} className="text-orange-400 shrink-0 group-hover:animate-bounce" />
-                                    <div className="text-left flex-1">
-                                        <div className="text-xs font-bold text-orange-300 mb-1">Saboter Infrastructure</div>
-                                        <div className="text-[10px] text-orange-200/70 leading-relaxed">
-                                            Désactive temporairement une mine (-50% prod pendant 1h)
-                                        </div>
-                                        <div className="flex items-center gap-2 mt-2 text-[9px] text-orange-400/80">
-                                            <Clock size={10} />
-                                            <span>Durée: 1 heure</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </button>
-
-                            {/* Option 2: Voler tech */}
-                            <button
-                                onClick={() => onSabotage('steal_tech')}
-                                className="w-full bg-purple-950/30 border border-purple-500/30 rounded-lg p-3 hover:bg-purple-950/50 transition-all duration-300 group card-depth hover:-translate-y-1 hover:shadow-lg"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <Eye size={20} className="text-purple-400 shrink-0 group-hover:animate-pulse" />
-                                    <div className="text-left flex-1">
-                                        <div className="text-xs font-bold text-purple-300 mb-1">Espionnage Industriel</div>
-                                        <div className="text-[10px] text-purple-200/70 leading-relaxed">
-                                            Vole des données techniques (-20% temps recherche suivante)
-                                        </div>
-                                        <div className="flex items-center gap-2 mt-2 text-[9px] text-purple-400/80">
-                                            <Skull size={10} />
-                                            <span>Risque: Élevé</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </button>
-                        </div>
-                    </Section>
+                        </Section>
+                    )}
                 </>
             )}
         </div>

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -84,6 +84,23 @@ export interface WsSpyAlert extends WsEvent {
   };
 }
 
+export interface WsSabotageDetected extends WsEvent {
+  type: 'sabotage_detected';
+  payload: {
+    attacker_name: string;
+    planet_name: string;
+    effect_type: 'disable_mine' | 'steal_tech';
+  };
+}
+
+export interface WsCasusBelliGranted extends WsEvent {
+  type: 'casus_belli_granted';
+  payload: {
+    target_name: string;
+    reason: string;
+  };
+}
+
 export interface WsPlanetStatus extends WsEvent {
   type: 'planet_status';
   payload: {
@@ -251,6 +268,29 @@ export function useWebSocket(planetId: string | null, options: UseWebSocketOptio
           toast.warning('🕵️ Espionnage détecté !', {
             description: `Depuis ${spyData.from}`,
           });
+          break;
+
+        case 'sabotage_detected':
+          const sabotageData = (data as WsSabotageDetected).payload;
+          const effectLabel = sabotageData.effect_type === 'disable_mine'
+            ? 'Mine désactivée'
+            : 'Données volées';
+          toast.error('🚨 SABOTAGE DÉTECTÉ !', {
+            description: `${sabotageData.attacker_name} a tenté de saboter ${sabotageData.planet_name} ! ${effectLabel}. Casus Belli accordé !`,
+            duration: 10000,
+            important: true,
+          });
+          window.dispatchEvent(new Event('sabotage-detected'));
+          break;
+
+        case 'casus_belli_granted':
+          const cbData = (data as WsCasusBelliGranted).payload;
+          toast.success('⚔️ CASUS BELLI ACCORDÉ !', {
+            description: `Vous pouvez attaquer ${cbData.target_name} sans pénalité ! Raison: ${cbData.reason}`,
+            duration: 8000,
+            important: true,
+          });
+          window.dispatchEvent(new Event('casus-belli-granted'));
           break;
 
         case 'planet_status':


### PR DESCRIPTION
…Socket notifications

Backend improvements:
- Add GET /sabotage/suffered endpoint to view sabotages on user's planets
- Add WebSocket events: sabotage_detected and casus_belli_granted
- Implement real-time notifications when sabotage is detected
- Fetch attacker username for notifications instead of planet name

Frontend improvements:
- Fix SpyModal to show clear message when tech advantage insufficient for sabotage
- Create SabotagesSufferedDashboard component with filters (active/expired/all)
- Redesign SabotagesDashboard to match PlanetOverview design patterns
- Redesign CasusBelliList to match PlanetOverview design patterns
- Add sabotages suffered menu item to ESPIONNAGE category in sidebar
- Add WebSocket handlers for sabotage_detected and casus_belli_granted events
- Show toast notifications for sabotage detection and casus belli grants

Design consistency:
- All new components now follow PlanetOverview design system
- Consistent color schemes (indigo/purple, emerald/green, red/orange)
- Matching typography, animations, and hover effects
- Card-based layouts with backdrop blur and depth effects

This addresses the critical bug where users couldn't find or understand why sabotage was unavailable, and provides complete visibility into both offensive and defensive sabotage operations with real-time notifications.