### PR TITLE
fix(admin): Wrap config data in 'configs' property for backend deseri…

### DIFF
--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -194,7 +194,7 @@ export default function AdminPanel() {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(editedConfig)
+        body: JSON.stringify({ configs: editedConfig })
       });
 
       if (res.ok) {


### PR DESCRIPTION
…alization

The backend expects config updates in the format { configs: {...} } but the frontend was sending the data directly as {...}. This caused silent JSON deserialization failures, preventing any config updates from being saved to the database and no logs appearing in the backend.

Fixes the issue where admin config changes (production_metal_base, etc.) were not being persisted to the database.