### PR TITLE
fix(game): Fix NaN errors and sync config key names across codebase

### DIFF
--- a/backend/src/game_logic.rs
+++ b/backend/src/game_logic.rs
@@ -527,14 +527,13 @@ pub fn resolve_pvp(
     let mut rng = rand::thread_rng();
 
     // Tech bonuses from config
-    let laser_bonus = config.get_config("combat_tech_laser_bonus", 0.1);
-    let energy_bonus = config.get_config("combat_tech_energy_bonus", 0.1);
-    let armour_bonus = config.get_config("combat_tech_armour_bonus", 0.1);
+    let laser_bonus = config.get_config("combat_laser_tech_bonus", 0.1);
+    let armour_bonus = config.get_config("combat_armour_tech_bonus", 0.1);
 
     let apply_techs = |base: UnitStats, techs: &CombatTechs| -> UnitStats {
         UnitStats {
             attack: base.attack * (1.0 + techs.laser as f64 * laser_bonus),
-            shield: base.shield * (1.0 + techs.energy as f64 * energy_bonus),
+            shield: base.shield, // Pas de tech bouclier pour l'instant
             hull: base.hull * (1.0 + techs.armour as f64 * armour_bonus),
         }
     };
@@ -616,8 +615,8 @@ pub fn resolve_pvp(
         let total_cargo_capacity = transporter_capacity + combat_ships_capacity;
 
         // Lire les paramètres de butin depuis la config
-        let loot_percentage = config.get_config("loot_percentage", 0.5);
-        let loot_max_per_resource = config.get_config("loot_max_per_resource", 50000.0);
+        let loot_percentage = config.get_config("combat_loot_percentage", 0.5);
+        let loot_max_per_resource = config.get_config("combat_loot_cap_per_resource", 50000.0);
 
         // Calculer le butin potentiel avec les valeurs configurables
         let potential_metal = (def_resources.metal * loot_percentage).min(loot_max_per_resource * cost_scaling(config));
@@ -658,7 +657,7 @@ pub fn resolve_pvp(
     let total_metal_lost = (att_h_lost + def_h_lost) as f64 * h_m + (att_c_lost + def_c_lost) as f64 * c_m;
     let total_crystal_lost = (att_h_lost + def_h_lost) as f64 * h_c + (att_c_lost + def_c_lost) as f64 * c_c;
 
-    let debris_percentage = config.get_config("debris_percentage", 0.3);
+    let debris_percentage = config.get_config("combat_debris_percentage", 0.3);
     let debris_m = total_metal_lost * debris_percentage;
     let debris_c = total_crystal_lost * debris_percentage;
 
@@ -680,8 +679,8 @@ pub fn simulate_combat(fleet_size: i32, defense_bonus: i32, config: &ServerConfi
     let mut rng = rand::thread_rng();
 
     // Niveau pirate aléatoire (configurable)
-    let pirate_min = config.get_config("expedition_pirate_strength_min", 10.0) as i32;
-    let pirate_max = config.get_config("expedition_pirate_strength_max", 100.0) as i32;
+    let pirate_min = config.get_config("expedition_pirate_scaling_min", 10.0) as i32;
+    let pirate_max = config.get_config("expedition_pirate_scaling_max", 100.0) as i32;
     let pirate_strength = rng.gen_range(pirate_min..pirate_max);
 
     let defense_multiplier = config.get_config("expedition_defense_bonus_multiplier", 5.0);

--- a/frontend/src/components/EmpireBar.tsx
+++ b/frontend/src/components/EmpireBar.tsx
@@ -148,8 +148,13 @@ export default function EmpireBar({ planet, onSwitchPlanet, unreadMessages = 0, 
   const calculateProduction = (level: number, baseFactor: number, growthFactor: number, resourceType: 'metal' | 'crystal' | 'deuterium') => {
     if (level === 0) return 0;
 
+    // Protection contre NaN - s'assurer que les valeurs sont des nombres
+    const safeBaseFactor = Number(baseFactor) || 0;
+    const safeGrowthFactor = Number(growthFactor) || 1;
+    if (safeBaseFactor === 0) return 0;
+
     // Production de base
-    let prod = baseFactor * level * Math.pow(growthFactor, level);
+    let prod = safeBaseFactor * level * Math.pow(safeGrowthFactor, level);
 
     // Bonus technologie énergie (configurable)
     const techLevel = planet.energy_tech_level || 0;
@@ -171,9 +176,9 @@ export default function EmpireBar({ planet, onSwitchPlanet, unreadMessages = 0, 
     return Math.floor(prod);
   };
 
-  const prodMetal = calculateProduction(planet.metal_mine_level || 0, config.production_metal_base, config.production_metal_growth, 'metal');
-  const prodCrystal = calculateProduction(planet.crystal_mine_level || 0, config.production_crystal_base, config.production_crystal_growth, 'crystal');
-  const prodDeut = calculateProduction(planet.deuterium_mine_level || 0, config.production_deuterium_base, config.production_deuterium_growth, 'deuterium');
+  const prodMetal = calculateProduction(planet.metal_mine_level || 0, config.production_metal_base || 30, config.production_metal_growth || 1.1, 'metal');
+  const prodCrystal = calculateProduction(planet.crystal_mine_level || 0, config.production_crystal_base || 20, config.production_crystal_growth || 1.1, 'crystal');
+  const prodDeut = calculateProduction(planet.deuterium_mine_level || 0, config.production_deuterium_base || 10, config.production_deuterium_growth || 1.05, 'deuterium');
 
   // Calcul de la capacité de stockage (600k base, x1.6 par niveau)
   const storageLevel = planet.resource_storage_level || 0;

--- a/frontend/src/components/ProductionStats.tsx
+++ b/frontend/src/components/ProductionStats.tsx
@@ -109,8 +109,20 @@ export default function ProductionStats({ planet, speedFactor = 10 }: { planet: 
 
   // Calcul de production avec tous les bonus
   const calculateProduction = (resourceType: 'metal' | 'crystal' | 'deuterium', level: number, baseFactor: number, growthFactor: number) => {
+    // Protection contre NaN
+    const safeBaseFactor = Number(baseFactor) || 0;
+    const safeGrowthFactor = Number(growthFactor) || 1;
+    if (safeBaseFactor === 0 || level === 0) return {
+      total: 0,
+      base: 0,
+      techBonus: 0,
+      energyRatio: 0,
+      slotsCount: 0,
+      slotBonus: 1,
+    };
+
     // Calcul de base
-    let prod = baseFactor * level * Math.pow(growthFactor, level);
+    let prod = safeBaseFactor * level * Math.pow(safeGrowthFactor, level);
 
     // Bonus technologie énergie (configurable via config)
     const techLevel = planet.energy_tech_level || 0;
@@ -139,9 +151,9 @@ export default function ProductionStats({ planet, speedFactor = 10 }: { planet: 
     };
   };
 
-  const prodMetal = calculateProduction('metal', planet.metal_mine_level, config.production_metal_base, config.production_metal_growth);
-  const prodCrystal = calculateProduction('crystal', planet.crystal_mine_level, config.production_crystal_base, config.production_crystal_growth);
-  const prodDeut = calculateProduction('deuterium', planet.deuterium_mine_level, config.production_deuterium_base, config.production_deuterium_growth);
+  const prodMetal = calculateProduction('metal', planet.metal_mine_level || 0, config.production_metal_base || 30, config.production_metal_growth || 1.1);
+  const prodCrystal = calculateProduction('crystal', planet.crystal_mine_level || 0, config.production_crystal_base || 20, config.production_crystal_growth || 1.1);
+  const prodDeut = calculateProduction('deuterium', planet.deuterium_mine_level || 0, config.production_deuterium_base || 10, config.production_deuterium_growth || 1.05);
 
   // Statistiques de combat
   const totalCombats = combatLogs.length;

--- a/frontend/src/hooks/useRealtimeResources.ts
+++ b/frontend/src/hooks/useRealtimeResources.ts
@@ -70,17 +70,24 @@ export function useRealtimeResources(
   ): number => {
     if (level === 0) return 0;
 
+    // Protection contre NaN
+    const safeBaseFactor = Number(baseFactor) || 0;
+    const safeGrowthFactor = Number(growthFactor) || 1;
+    const safeTechBonus = Number(techBonus) || 1;
+    const safeSlotBonus = Number(slotBonus) || 1;
+    if (safeBaseFactor === 0) return 0;
+
     // Production de base
-    let prod = baseFactor * level * Math.pow(growthFactor, level);
+    let prod = safeBaseFactor * level * Math.pow(safeGrowthFactor, level);
 
     // Bonus tech énergie
-    prod *= techBonus;
+    prod *= safeTechBonus;
 
     // Ratio énergétique
     prod *= (energyRatio / 100);
 
     // Bonus slots
-    prod *= slotBonus;
+    prod *= safeSlotBonus;
 
     // Speed factor
     prod *= speedFactor;


### PR DESCRIPTION
Backend (game_logic.rs):
- Fixed config key names to match database schema:
  * combat_tech_laser_bonus → combat_laser_tech_bonus
  * loot_percentage → combat_loot_percentage
  * loot_max_per_resource → combat_loot_cap_per_resource
  * debris_percentage → combat_debris_percentage
  * expedition_pirate_strength_* → expedition_pirate_scaling_*
- Removed combat_tech_energy_bonus (doesn't exist in DB)
- Removed energy bonus from shield calculations (not implemented)

Frontend (EmpireBar, ProductionStats, useRealtimeResources):
- Added Number() protection against NaN in all production calculations
- Added fallback default values (|| 30, || 1.1, etc.) for config values
- Protected calculateProduction functions with safe type conversions

This fixes:
1. NaN displays in empire bar, stats, and production overview
2. Inconsistent config key usage between backend logic and database
3. Runtime errors when config values are undefined or malformed