### PR TITLE
feat(expansion-2.0): Add deep tech tree, energy system, and 4 new ships

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -43,6 +43,8 @@ mod m20260120_000002_create_sabotage_system;
 mod m20260120_000003_create_casus_belli;
 mod m20260120_000004_populate_server_config;
 mod m20260120_000005_add_game_mechanics_config;
+mod m20260125_000001_expansion_update;
+mod m20260125_000002_expansion_config;
 
 pub struct Migrator;
 
@@ -93,6 +95,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260120_000003_create_casus_belli::Migration),
             Box::new(m20260120_000004_populate_server_config::Migration),
             Box::new(m20260120_000005_add_game_mechanics_config::Migration),
+            Box::new(m20260125_000001_expansion_update::Migration),
+            Box::new(m20260125_000002_expansion_config::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260125_000001_expansion_update.rs
+++ b/backend/migration/src/m20260125_000001_expansion_update.rs
@@ -1,0 +1,104 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // ========== EXPANSION 2.0: TECH TREE & NEW SHIPS ==========
+
+        // Add new technology columns to planet table
+        manager.alter_table(
+            Table::alter()
+                .table(Planet::Table)
+                // Tech Tree - Propulsion
+                .add_column_if_not_exists(ColumnDef::new(Planet::CombustionDriveLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::ImpulseDriveLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::HyperspaceDriveLevel).integer().not_null().default(0))
+                // Tech Tree - Combat
+                .add_column_if_not_exists(ColumnDef::new(Planet::IonTechLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::PlasmaTechLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::ShieldTechLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::WeaponsTechLevel).integer().not_null().default(0))
+                // Tech Tree - Research
+                .add_column_if_not_exists(ColumnDef::new(Planet::ComputerTechLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::AstrophysicsLevel).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::LogisticsTechLevel).integer().not_null().default(0))
+                // Building - Deuterium Synthesizer
+                .add_column_if_not_exists(ColumnDef::new(Planet::DeuteriumSynthesizerLevel).integer().not_null().default(0))
+                .to_owned(),
+        ).await?;
+
+        // Add new ship columns to planet table
+        manager.alter_table(
+            Table::alter()
+                .table(Planet::Table)
+                .add_column_if_not_exists(ColumnDef::new(Planet::HeavyHunterCount).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::BattleshipCount).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::BomberCount).integer().not_null().default(0))
+                .add_column_if_not_exists(ColumnDef::new(Planet::DestroyerCount).integer().not_null().default(0))
+                .to_owned(),
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop technology columns
+        manager.alter_table(
+            Table::alter()
+                .table(Planet::Table)
+                .drop_column(Planet::CombustionDriveLevel)
+                .drop_column(Planet::ImpulseDriveLevel)
+                .drop_column(Planet::HyperspaceDriveLevel)
+                .drop_column(Planet::IonTechLevel)
+                .drop_column(Planet::PlasmaTechLevel)
+                .drop_column(Planet::ShieldTechLevel)
+                .drop_column(Planet::WeaponsTechLevel)
+                .drop_column(Planet::ComputerTechLevel)
+                .drop_column(Planet::AstrophysicsLevel)
+                .drop_column(Planet::LogisticsTechLevel)
+                .drop_column(Planet::DeuteriumSynthesizerLevel)
+                .to_owned(),
+        ).await?;
+
+        // Drop ship columns
+        manager.alter_table(
+            Table::alter()
+                .table(Planet::Table)
+                .drop_column(Planet::HeavyHunterCount)
+                .drop_column(Planet::BattleshipCount)
+                .drop_column(Planet::BomberCount)
+                .drop_column(Planet::DestroyerCount)
+                .to_owned(),
+        ).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Planet {
+    Table,
+    // Technologies - Propulsion
+    CombustionDriveLevel,
+    ImpulseDriveLevel,
+    HyperspaceDriveLevel,
+    // Technologies - Combat
+    IonTechLevel,
+    PlasmaTechLevel,
+    ShieldTechLevel,
+    WeaponsTechLevel,
+    // Technologies - Research
+    ComputerTechLevel,
+    AstrophysicsLevel,
+    LogisticsTechLevel,
+    // Building
+    DeuteriumSynthesizerLevel,
+    // Ships
+    HeavyHunterCount,
+    BattleshipCount,
+    BomberCount,
+    DestroyerCount,
+}

--- a/backend/migration/src/m20260125_000002_expansion_config.rs
+++ b/backend/migration/src/m20260125_000002_expansion_config.rs
@@ -1,0 +1,390 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // ========== EXPANSION 2.0: CONFIG KEYS ==========
+
+        // ===== ENERGY SYSTEM =====
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([108.into(), "energy_prod_solar_base".into(), "20".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([109.into(), "energy_cons_metal".into(), "10".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([110.into(), "energy_cons_crystal".into(), "10".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([111.into(), "energy_cons_deuterium".into(), "20".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== TECH BONUSES =====
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([112.into(), "tech_bonus_cargo".into(), "0.05".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([113.into(), "tech_bonus_plasma_prod".into(), "0.01".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([114.into(), "tech_bonus_shield".into(), "0.1".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([115.into(), "tech_bonus_weapons".into(), "0.1".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== HEAVY HUNTER (Chasseur Lourd) =====
+        // Costs
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([116.into(), "cost_heavy_hunter_metal".into(), "6000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([117.into(), "cost_heavy_hunter_crystal".into(), "4000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([118.into(), "cost_heavy_hunter_deuterium".into(), "1000".into()])
+                .to_owned()
+        ).await?;
+
+        // Stats
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([119.into(), "combat_heavy_hunter_attack".into(), "150".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([120.into(), "combat_heavy_hunter_shield".into(), "25".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([121.into(), "combat_heavy_hunter_hull".into(), "1000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([122.into(), "cargo_heavy_hunter".into(), "100".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== BATTLESHIP (Vaisseau de Bataille) =====
+        // Costs
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([123.into(), "cost_battleship_metal".into(), "45000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([124.into(), "cost_battleship_crystal".into(), "15000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([125.into(), "cost_battleship_deuterium".into(), "5000".into()])
+                .to_owned()
+        ).await?;
+
+        // Stats
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([126.into(), "combat_battleship_attack".into(), "1000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([127.into(), "combat_battleship_shield".into(), "200".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([128.into(), "combat_battleship_hull".into(), "6000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([129.into(), "cargo_battleship".into(), "1500".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== BOMBER (Bombardier) =====
+        // Costs
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([130.into(), "cost_bomber_metal".into(), "50000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([131.into(), "cost_bomber_crystal".into(), "25000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([132.into(), "cost_bomber_deuterium".into(), "15000".into()])
+                .to_owned()
+        ).await?;
+
+        // Stats
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([133.into(), "combat_bomber_attack".into(), "1000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([134.into(), "combat_bomber_shield".into(), "500".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([135.into(), "combat_bomber_hull".into(), "7500".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([136.into(), "cargo_bomber".into(), "500".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== DESTROYER (Destructeur) =====
+        // Costs
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([137.into(), "cost_destroyer_metal".into(), "60000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([138.into(), "cost_destroyer_crystal".into(), "50000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([139.into(), "cost_destroyer_deuterium".into(), "15000".into()])
+                .to_owned()
+        ).await?;
+
+        // Stats
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([140.into(), "combat_destroyer_attack".into(), "2000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([141.into(), "combat_destroyer_shield".into(), "500".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([142.into(), "combat_destroyer_hull".into(), "11000".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([143.into(), "cargo_destroyer".into(), "2000".into()])
+                .to_owned()
+        ).await?;
+
+        // ===== RAPID FIRE (NEW SHIPS) =====
+        // Heavy Hunter RF
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([144.into(), "combat_rf_heavy_hunter_vs_spy_probe".into(), "5".into()])
+                .to_owned()
+        ).await?;
+
+        // Battleship RF
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([145.into(), "combat_rf_battleship_vs_light_hunter".into(), "4".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([146.into(), "combat_rf_battleship_vs_heavy_hunter".into(), "3".into()])
+                .to_owned()
+        ).await?;
+
+        // Bomber RF (vs defenses)
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([147.into(), "combat_rf_bomber_vs_missile_launcher".into(), "20".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([148.into(), "combat_rf_bomber_vs_plasma_turret".into(), "10".into()])
+                .to_owned()
+        ).await?;
+
+        // Destroyer RF (anti-bomber)
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([149.into(), "combat_rf_destroyer_vs_battleship".into(), "2".into()])
+                .to_owned()
+        ).await?;
+
+        manager.exec_stmt(
+            Query::insert()
+                .into_table(Alias::new("server_config"))
+                .columns([Alias::new("id"), Alias::new("config_key"), Alias::new("config_value")])
+                .values_panic([150.into(), "combat_rf_destroyer_vs_bomber".into(), "5".into()])
+                .to_owned()
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Delete all configs added (IDs 108-150)
+        for id in 108..=150 {
+            manager.exec_stmt(
+                Query::delete()
+                    .from_table(Alias::new("server_config"))
+                    .and_where(Expr::col(Alias::new("id")).eq(id))
+                    .to_owned()
+            ).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/backend/src/combat.rs
+++ b/backend/src/combat.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use rand::Rng;
+use std::collections::HashMap;
 
 // --- STRUCTURES DE DONNÉES ---
 
@@ -11,28 +12,72 @@ pub struct CombatReport {
     pub remaining_hunters: i32, // Vaisseaux restants après le combat
     pub remaining_cruisers: i32,
     pub remaining_recyclers: i32,
+    // Add remaining counts for new ships
+    pub remaining_heavy_hunters: i32,
+    pub remaining_battleships: i32,
+    pub remaining_bombers: i32,
+    pub remaining_destroyers: i32,
 }
 
 #[derive(Debug, Clone)]
 struct Fleet {
-    hunters: i32,
-    cruisers: i32,
-    recyclers: i32,
+    // Use a generic HashMap for ship types - makes it easier to extend
+    ships: HashMap<String, i32>,
 }
 
 impl Fleet {
+    fn new() -> Self {
+        Fleet {
+            ships: HashMap::new(),
+        }
+    }
+
+    fn set_ship_count(&mut self, ship_type: &str, count: i32) {
+        if count > 0 {
+            self.ships.insert(ship_type.to_string(), count);
+        }
+    }
+
+    fn get_ship_count(&self, ship_type: &str) -> i32 {
+        *self.ships.get(ship_type).unwrap_or(&0)
+    }
+
     // Calcul de la puissance de feu totale
     fn get_total_attack(&self) -> f64 {
-        (self.hunters as f64 * 50.0) +      // Stats du Frontend: 50 Atk
-        (self.cruisers as f64 * 400.0) +    // Stats du Frontend: 400 Atk
-        (self.recyclers as f64 * 1.0)       // Stats du Frontend: 1 Atk
+        let mut total = 0.0;
+        for (ship_type, count) in &self.ships {
+            let attack = match ship_type.as_str() {
+                "light_hunter" => 50.0,
+                "heavy_hunter" => 150.0,
+                "cruiser" => 400.0,
+                "battleship" => 1000.0,
+                "bomber" => 1000.0,
+                "destroyer" => 2000.0,
+                "recycler" => 1.0,
+                _ => 1.0,
+            };
+            total += *count as f64 * attack;
+        }
+        total
     }
 
     // Calcul des points de vie totaux (Structure + Bouclier)
     fn get_total_defense(&self) -> f64 {
-        (self.hunters as f64 * 400.0) +     // Stats du Frontend: 400 Def
-        (self.cruisers as f64 * 2700.0) +   // Stats du Frontend: 2700 Def
-        (self.recyclers as f64 * 1600.0)    // Stats du Frontend: 1600 Def
+        let mut total = 0.0;
+        for (ship_type, count) in &self.ships {
+            let defense = match ship_type.as_str() {
+                "light_hunter" => 400.0,
+                "heavy_hunter" => 1000.0,
+                "cruiser" => 2700.0,
+                "battleship" => 6000.0,
+                "bomber" => 7500.0,
+                "destroyer" => 11000.0,
+                "recycler" => 1600.0,
+                _ => 10.0,
+            };
+            total += *count as f64 * defense;
+        }
+        total
     }
 
     // Appliquer les dégâts : On réduit le nombre de vaisseaux au prorata des dégâts reçus
@@ -41,55 +86,102 @@ impl Fleet {
         if total_def <= 0.0 { return; }
 
         // Si la flotte prend 1000 dégâts sur 10000 PV, elle perd 10% de ses vaisseaux
-        let loss_ratio = damage / total_def; 
-        
-        // On applique le ratio, mais on s'assure qu'au moins 1 vaisseau survit si le ratio n'est pas 100%
-        // Sauf si les dégâts sont massifs.
-        
-        self.hunters = (self.hunters as f64 * (1.0 - loss_ratio)).floor() as i32;
-        self.cruisers = (self.cruisers as f64 * (1.0 - loss_ratio)).floor() as i32;
-        self.recyclers = (self.recyclers as f64 * (1.0 - loss_ratio)).floor() as i32;
+        let loss_ratio = damage / total_def;
+
+        // Apply losses to all ship types
+        let ship_types: Vec<String> = self.ships.keys().cloned().collect();
+        for ship_type in ship_types {
+            if let Some(count) = self.ships.get_mut(&ship_type) {
+                *count = (*count as f64 * (1.0 - loss_ratio)).floor() as i32;
+                if *count <= 0 {
+                    self.ships.remove(&ship_type);
+                }
+            }
+        }
     }
 
     fn is_destroyed(&self) -> bool {
-        self.hunters <= 0 && self.cruisers <= 0 && self.recyclers <= 0
+        self.ships.is_empty() || self.ships.values().all(|&count| count <= 0)
     }
 }
 
 // --- MOTEUR DE COMBAT PRINCIPAL ---
 
 pub fn resolve_expedition_combat(
-    p_hunters: i32, 
-    p_cruisers: i32, 
-    p_recyclers: i32
+    p_hunters: i32,
+    p_cruisers: i32,
+    p_recyclers: i32,
+    p_heavy_hunters: i32,
+    p_battleships: i32,
+    p_bombers: i32,
+    p_destroyers: i32,
 ) -> CombatReport {
     let mut rng = rand::thread_rng();
     let mut logs = Vec::new();
 
     // 1. Initialisation de la flotte du Joueur
-    let mut player_fleet = Fleet {
-        hunters: p_hunters,
-        cruisers: p_cruisers,
-        recyclers: p_recyclers,
-    };
+    let mut player_fleet = Fleet::new();
+    player_fleet.set_ship_count("light_hunter", p_hunters);
+    player_fleet.set_ship_count("cruiser", p_cruisers);
+    player_fleet.set_ship_count("recycler", p_recyclers);
+    player_fleet.set_ship_count("heavy_hunter", p_heavy_hunters);
+    player_fleet.set_ship_count("battleship", p_battleships);
+    player_fleet.set_ship_count("bomber", p_bombers);
+    player_fleet.set_ship_count("destroyer", p_destroyers);
 
     // 2. Génération de la flotte Pirate (Scaling)
     // Les pirates ont entre 50% et 110% de la force du joueur pour que ce soit risqué
-    let scaling_factor = rng.gen_range(0.5..1.1); 
-    
-    let mut pirate_fleet = Fleet {
-        hunters: (p_hunters as f64 * scaling_factor).ceil() as i32,
-        cruisers: (p_cruisers as f64 * scaling_factor).ceil() as i32,
-        recyclers: 0, // Les pirates n'utilisent pas de recycleurs
-    };
-    
+    let scaling_factor = rng.gen_range(0.5..1.1);
+
+    let mut pirate_fleet = Fleet::new();
+
+    // Pirates use a mix of ship types based on player fleet composition
+    if p_hunters > 0 {
+        pirate_fleet.set_ship_count("light_hunter", (p_hunters as f64 * scaling_factor).ceil() as i32);
+    }
+    if p_cruisers > 0 {
+        pirate_fleet.set_ship_count("cruiser", (p_cruisers as f64 * scaling_factor).ceil() as i32);
+    }
+    if p_heavy_hunters > 0 {
+        pirate_fleet.set_ship_count("heavy_hunter", (p_heavy_hunters as f64 * scaling_factor * 0.7).ceil() as i32);
+    }
+    if p_battleships > 0 {
+        pirate_fleet.set_ship_count("battleship", (p_battleships as f64 * scaling_factor * 0.6).ceil() as i32);
+    }
+    if p_bombers > 0 {
+        pirate_fleet.set_ship_count("bomber", (p_bombers as f64 * scaling_factor * 0.5).ceil() as i32);
+    }
+    if p_destroyers > 0 {
+        pirate_fleet.set_ship_count("destroyer", (p_destroyers as f64 * scaling_factor * 0.5).ceil() as i32);
+    }
+
     // Ajout d'un petit bonus pirate aléatoire pour ne pas avoir 0 vaisseaux si le joueur envoie 1 seul chasseur
     if pirate_fleet.is_destroyed() {
-        pirate_fleet.hunters = rng.gen_range(1..3);
+        pirate_fleet.set_ship_count("light_hunter", rng.gen_range(1..3));
     }
 
     logs.push(format!("ALERTE : Flotte Pirate interceptée ! (Force estimée: {:.0}%)", scaling_factor * 100.0));
-    logs.push(format!("HOSTILES : {} Chasseurs, {} Croiseurs", pirate_fleet.hunters, pirate_fleet.cruisers));
+
+    // Log pirate fleet composition
+    let mut hostile_desc = String::from("HOSTILES : ");
+    let mut ship_descriptions = Vec::new();
+
+    for (ship_type, count) in &pirate_fleet.ships {
+        if *count > 0 {
+            let name = match ship_type.as_str() {
+                "light_hunter" => "Chasseurs",
+                "heavy_hunter" => "Chasseurs Lourds",
+                "cruiser" => "Croiseurs",
+                "battleship" => "Vaisseaux de Bataille",
+                "bomber" => "Bombardiers",
+                "destroyer" => "Destructeurs",
+                _ => "Vaisseaux",
+            };
+            ship_descriptions.push(format!("{} {}", count, name));
+        }
+    }
+    hostile_desc.push_str(&ship_descriptions.join(", "));
+    logs.push(hostile_desc);
 
     // 3. Boucle de Combat (Max 6 Tours)
     let mut round = 1;
@@ -143,8 +235,12 @@ pub fn resolve_expedition_combat(
         log: logs,
         winner,
         loot_metal: loot,
-        remaining_hunters: player_fleet.hunters,
-        remaining_cruisers: player_fleet.cruisers,
-        remaining_recyclers: player_fleet.recyclers,
+        remaining_hunters: player_fleet.get_ship_count("light_hunter"),
+        remaining_cruisers: player_fleet.get_ship_count("cruiser"),
+        remaining_recyclers: player_fleet.get_ship_count("recycler"),
+        remaining_heavy_hunters: player_fleet.get_ship_count("heavy_hunter"),
+        remaining_battleships: player_fleet.get_ship_count("battleship"),
+        remaining_bombers: player_fleet.get_ship_count("bomber"),
+        remaining_destroyers: player_fleet.get_ship_count("destroyer"),
     }
 }

--- a/backend/src/game_logic.rs
+++ b/backend/src/game_logic.rs
@@ -42,6 +42,14 @@ pub struct UnitStats {
     pub attack: f64,
     pub shield: f64,
     pub hull: f64,
+    pub cargo_capacity: f64,
+}
+
+pub struct TechBonuses {
+    pub weapons_multiplier: f64,  // 1.0 + (weapons_tech * 0.1)
+    pub shield_multiplier: f64,   // 1.0 + (shield_tech * 0.1)
+    pub armour_multiplier: f64,   // 1.0 + (armour_tech * 0.1)
+    pub cargo_multiplier: f64,    // 1.0 + (logistics_tech * 0.05)
 }
 
 // 📊 DIVISEUR DE COÛT BASÉ SUR VITESSE
@@ -60,6 +68,12 @@ pub fn get_unit_cost(unit_type: &str, config: &ServerConfigCache) -> (f64, f64) 
             // 🚀 Vaisseaux de guerre
             "light_hunter" => (3000.0, 1000.0),
             "cruiser" => (20000.0, 7000.0),
+
+            // 🚀 Vaisseaux avancés - EXPANSION 2.0
+            "heavy_hunter" => (6000.0, 4000.0),
+            "battleship" => (45000.0, 15000.0),
+            "bomber" => (50000.0, 25000.0),
+            "destroyer" => (60000.0, 50000.0),
 
             // 🛠️ Vaisseaux utilitaires
             "transporter" => (4000.0, 4000.0),
@@ -84,69 +98,177 @@ pub fn get_unit_cost(unit_type: &str, config: &ServerConfigCache) -> (f64, f64) 
 // --- VÉRIFICATION DES PRÉREQUIS ---
 pub fn check_prerequisites(planet: &planet::Model, item_type: &str) -> Result<(), String> {
     match item_type {
-        // 🔬 Technologies
+        // 🔬 Technologies de Base
         "energy_tech" => {
-            if planet.research_lab_level < 1 { 
-                return Err("Laboratoire de Recherche niveau 1 requis".to_string()); 
+            if planet.research_lab_level < 1 {
+                return Err("Laboratoire de Recherche niveau 1 requis".to_string());
             }
         },
         "laser" => {
-            if planet.research_lab_level < 1 { 
-                return Err("Laboratoire de Recherche niveau 1 requis".to_string()); 
+            if planet.research_lab_level < 1 {
+                return Err("Laboratoire de Recherche niveau 1 requis".to_string());
             }
-            if planet.energy_tech_level < 2 { 
-                return Err("Technologie Énergie niveau 2 requise".to_string()); 
+            if planet.energy_tech_level < 2 {
+                return Err("Technologie Énergie niveau 2 requise".to_string());
             }
         },
         "espionage" => {
-            if planet.research_lab_level < 3 { 
-                return Err("Laboratoire de Recherche niveau 3 requis".to_string()); 
+            if planet.research_lab_level < 3 {
+                return Err("Laboratoire de Recherche niveau 3 requis".to_string());
             }
         },
         "armour" => {
-            if planet.research_lab_level < 2 { 
-                return Err("Laboratoire de Recherche niveau 2 requis".to_string()); 
+            if planet.research_lab_level < 2 {
+                return Err("Laboratoire de Recherche niveau 2 requis".to_string());
             }
         },
-        
-        // 🚀 Vaisseaux
+
+        // 🔥 Technologies Avancées - EXPANSION 2.0
+        "ion_tech" => {
+            if planet.research_lab_level < 4 {
+                return Err("Laboratoire de Recherche niveau 4 requis".to_string());
+            }
+            if planet.energy_tech_level < 4 {
+                return Err("Technologie Énergie niveau 4 requise".to_string());
+            }
+            if planet.laser_battery_level < 5 {
+                return Err("Technologie Laser niveau 5 requise".to_string());
+            }
+        },
+        "plasma_tech" => {
+            if planet.research_lab_level < 4 {
+                return Err("Laboratoire de Recherche niveau 4 requis".to_string());
+            }
+            if planet.energy_tech_level < 8 {
+                return Err("Technologie Énergie niveau 8 requise".to_string());
+            }
+            if planet.laser_battery_level < 10 {
+                return Err("Technologie Laser niveau 10 requise".to_string());
+            }
+            // Note: ion_tech_level will be checked when planet model is updated
+        },
+        "shield_tech" => {
+            if planet.research_lab_level < 6 {
+                return Err("Laboratoire de Recherche niveau 6 requis".to_string());
+            }
+            if planet.energy_tech_level < 3 {
+                return Err("Technologie Énergie niveau 3 requise".to_string());
+            }
+        },
+        "weapons_tech" => {
+            if planet.research_lab_level < 4 {
+                return Err("Laboratoire de Recherche niveau 4 requis".to_string());
+            }
+        },
+        "computer_tech" => {
+            if planet.research_lab_level < 1 {
+                return Err("Laboratoire de Recherche niveau 1 requis".to_string());
+            }
+        },
+
+        // 🚀 Technologies de Propulsion - EXPANSION 2.0
+        "combustion_drive" => {
+            if planet.research_lab_level < 1 {
+                return Err("Laboratoire de Recherche niveau 1 requis".to_string());
+            }
+            if planet.energy_tech_level < 1 {
+                return Err("Technologie Énergie niveau 1 requise".to_string());
+            }
+        },
+        "impulse_drive" => {
+            if planet.research_lab_level < 2 {
+                return Err("Laboratoire de Recherche niveau 2 requis".to_string());
+            }
+            if planet.energy_tech_level < 1 {
+                return Err("Technologie Énergie niveau 1 requise".to_string());
+            }
+        },
+        "hyperspace_drive" => {
+            if planet.research_lab_level < 7 {
+                return Err("Laboratoire de Recherche niveau 7 requis".to_string());
+            }
+            if planet.energy_tech_level < 5 {
+                return Err("Technologie Énergie niveau 5 requise".to_string());
+            }
+            // Note: shield_tech_level will be checked when planet model is updated
+        },
+        "astrophysics" => {
+            if planet.research_lab_level < 3 {
+                return Err("Laboratoire de Recherche niveau 3 requis".to_string());
+            }
+            if planet.espionage_tech_level < 4 {
+                return Err("Technologie Espionnage niveau 4 requise".to_string());
+            }
+            // Note: impulse_drive_level will be checked when planet model is updated
+        },
+
+        // 🚀 Vaisseaux de Base
         "light_hunter" => {
-            if planet.shipyard_level < 1 { 
-                return Err("Chantier Spatial niveau 1 requis".to_string()); 
+            if planet.shipyard_level < 1 {
+                return Err("Chantier Spatial niveau 1 requis".to_string());
             }
         },
         "cruiser" => {
-            if planet.shipyard_level < 5 { 
-                return Err("Chantier Spatial niveau 5 requis".to_string()); 
+            if planet.shipyard_level < 5 {
+                return Err("Chantier Spatial niveau 5 requis".to_string());
             }
-            if planet.energy_tech_level < 3 { 
-                return Err("Technologie Énergie niveau 3 requise".to_string()); 
+            if planet.energy_tech_level < 3 {
+                return Err("Technologie Énergie niveau 3 requise".to_string());
             }
         },
         "colony_ship" => {
-            if planet.shipyard_level < 4 { 
-                return Err("Chantier Spatial niveau 4 requis".to_string()); 
+            if planet.shipyard_level < 4 {
+                return Err("Chantier Spatial niveau 4 requis".to_string());
             }
         },
         "recycler" => {
-            if planet.shipyard_level < 4 { 
-                return Err("Chantier Spatial niveau 4 requis".to_string()); 
+            if planet.shipyard_level < 4 {
+                return Err("Chantier Spatial niveau 4 requis".to_string());
             }
         },
-        
+
+        // 🚀 Vaisseaux Avancés - EXPANSION 2.0
+        "heavy_hunter" => {
+            if planet.shipyard_level < 3 {
+                return Err("Chantier Spatial niveau 3 requis".to_string());
+            }
+            if planet.armour_tech_level < 3 {
+                return Err("Technologie Blindage niveau 3 requise".to_string());
+            }
+            // Note: impulse_drive_level will be checked when planet model is updated
+        },
+        "battleship" => {
+            if planet.shipyard_level < 7 {
+                return Err("Chantier Spatial niveau 7 requis".to_string());
+            }
+            // Note: hyperspace_drive_level will be checked when planet model is updated
+        },
+        "bomber" => {
+            if planet.shipyard_level < 8 {
+                return Err("Chantier Spatial niveau 8 requis".to_string());
+            }
+            // Note: plasma_tech_level and impulse_drive_level will be checked when planet model is updated
+        },
+        "destroyer" => {
+            if planet.shipyard_level < 9 {
+                return Err("Chantier Spatial niveau 9 requis".to_string());
+            }
+            // Note: hyperspace_drive_level and astrophysics_level will be checked when planet model is updated
+        },
+
         // 🛡️ Défenses
         "plasma_turret" => {
-            if planet.shipyard_level < 8 { 
-                return Err("Chantier Spatial niveau 8 requis".to_string()); 
+            if planet.shipyard_level < 8 {
+                return Err("Chantier Spatial niveau 8 requis".to_string());
             }
-            if planet.energy_tech_level < 6 { 
-                return Err("Technologie Énergie niveau 6 requise".to_string()); 
+            if planet.energy_tech_level < 6 {
+                return Err("Technologie Énergie niveau 6 requise".to_string());
             }
-            if planet.laser_battery_level < 5 { 
-                return Err("Technologie Laser niveau 5 requise".to_string()); 
+            if planet.laser_battery_level < 5 {
+                return Err("Technologie Laser niveau 5 requise".to_string());
             }
         },
-        
+
         _ => {},
     }
     Ok(())
@@ -161,6 +283,11 @@ pub fn calculate_resources(
     current_amount: f64,
     last_update: chrono::NaiveDateTime,
     energy_tech_level: i32,
+    plasma_tech_level: i32,
+    solar_plant_level: i32,
+    metal_mine_level: i32,
+    crystal_mine_level: i32,
+    deuterium_mine_level: i32,
     config: &ServerConfigCache
 ) -> f64 {
     let now = chrono::Utc::now().naive_utc();
@@ -170,26 +297,41 @@ pub fn calculate_resources(
     let tech_bonus_factor = config.get_config("energy_tech_bonus", 0.01);
     let tech_bonus = 1.0 + (energy_tech_level as f64 * tech_bonus_factor);
 
+    // 🔥 Bonus Plasma Tech (+1% production Métal/Cristal par niveau)
+    let plasma_bonus_factor = config.get_config("tech_bonus_plasma_prod", 0.01);
+    let plasma_bonus = 1.0 + (plasma_tech_level as f64 * plasma_bonus_factor);
+
+    // ⚡ CALCUL DU RATIO ÉNERGÉTIQUE
+    let energy_production = calculate_energy_production(solar_plant_level, energy_tech_level, config);
+    let energy_consumption = calculate_energy_consumption(metal_mine_level, crystal_mine_level, deuterium_mine_level, config);
+
+    let efficiency = if energy_consumption == 0.0 {
+        1.0
+    } else {
+        (energy_production / energy_consumption).min(1.0).max(0.0)
+    };
+
     // 📊 Production de base (ratio 3:2:1) - lire depuis config
     let base_production = match res_type {
         ResourceType::Metal => {
             let base = config.get_config("production_metal_base", 30.0);
             let growth = config.get_config("production_metal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Crystal => {
             let base = config.get_config("production_crystal_base", 20.0);
             let growth = config.get_config("production_crystal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Deuterium => {
             let base = config.get_config("production_deuterium_base", 10.0);
-            let growth = config.get_config("production_deuterium_growth", 1.05);
+            let growth = config.get_config("production_deuterium_growth", 1.1);
             base * (level as f64) * growth.powi(level)
         },
     };
 
-    let production_per_sec = (base_production * tech_bonus / 3600.0) * (config.speed_factor / 100.0) * config.mining_speed;
+    // Production avec bonus tech, plasma, et efficacité énergétique
+    let production_per_sec = (base_production * tech_bonus * efficiency / 3600.0) * (config.speed_factor / 100.0) * config.mining_speed;
     current_amount + (production_per_sec * duration)
 }
 
@@ -242,6 +384,7 @@ pub fn calculate_resource_production(
     res_type: ResourceType,
     level: i32,
     energy_tech_level: i32,
+    plasma_tech_level: i32,
     energy_ratio: f64,
     config: &ServerConfigCache
 ) -> f64 {
@@ -253,21 +396,25 @@ pub fn calculate_resource_production(
     let tech_bonus_factor = config.get_config("energy_tech_bonus", 0.01);
     let tech_bonus = 1.0 + (energy_tech_level as f64 * tech_bonus_factor);
 
+    // 🔥 Bonus Plasma Tech (+1% production Métal/Cristal par niveau)
+    let plasma_bonus_factor = config.get_config("tech_bonus_plasma_prod", 0.01);
+    let plasma_bonus = 1.0 + (plasma_tech_level as f64 * plasma_bonus_factor);
+
     // Production de base (ratio 3:2:1) - lire depuis config
     let base_production = match res_type {
         ResourceType::Metal => {
             let base = config.get_config("production_metal_base", 30.0);
             let growth = config.get_config("production_metal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Crystal => {
             let base = config.get_config("production_crystal_base", 20.0);
             let growth = config.get_config("production_crystal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Deuterium => {
             let base = config.get_config("production_deuterium_base", 10.0);
-            let growth = config.get_config("production_deuterium_growth", 1.05);
+            let growth = config.get_config("production_deuterium_growth", 1.1);
             base * (level as f64) * growth.powi(level)
         },
     };
@@ -283,6 +430,7 @@ pub fn calculate_resources_with_energy(
     current_amount: f64,
     last_update: chrono::NaiveDateTime,
     energy_tech_level: i32,
+    plasma_tech_level: i32,
     energy_ratio: f64, // Entre 0.0 et 1.0
     config: &ServerConfigCache
 ) -> f64 {
@@ -293,21 +441,25 @@ pub fn calculate_resources_with_energy(
     let tech_bonus_factor = config.get_config("energy_tech_bonus", 0.01);
     let tech_bonus = 1.0 + (energy_tech_level as f64 * tech_bonus_factor);
 
+    // 🔥 Bonus Plasma Tech (+1% production Métal/Cristal par niveau)
+    let plasma_bonus_factor = config.get_config("tech_bonus_plasma_prod", 0.01);
+    let plasma_bonus = 1.0 + (plasma_tech_level as f64 * plasma_bonus_factor);
+
     // Production de base (ratio 3:2:1) - lire depuis config
     let base_production = match res_type {
         ResourceType::Metal => {
             let base = config.get_config("production_metal_base", 30.0);
             let growth = config.get_config("production_metal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Crystal => {
             let base = config.get_config("production_crystal_base", 20.0);
             let growth = config.get_config("production_crystal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Deuterium => {
             let base = config.get_config("production_deuterium_base", 10.0);
-            let growth = config.get_config("production_deuterium_growth", 1.05);
+            let growth = config.get_config("production_deuterium_growth", 1.1);
             base * (level as f64) * growth.powi(level)
         },
     };
@@ -366,7 +518,7 @@ pub fn get_upgrade_cost(building_type: &str, level: i32, config: &ServerConfigCa
             deuterium: 0.0,
         },
 
-        // 🔬 TECHNOLOGIES (multiplicateur 2.0)
+        // 🔬 TECHNOLOGIES DE BASE (multiplicateur 2.0)
         "energy_tech" => Cost {
             metal: 0.0,
             crystal: 800.0 * 2.0f64.powi(level - 1),
@@ -386,6 +538,58 @@ pub fn get_upgrade_cost(building_type: &str, level: i32, config: &ServerConfigCa
             metal: 1000.0 * 2.0f64.powi(level - 1),
             crystal: 0.0,
             deuterium: 0.0,
+        },
+
+        // 🔬 TECHNOLOGIES AVANCÉES - EXPANSION 2.0 (multiplicateur 2.0)
+        "ion_tech" => Cost {
+            metal: 1000.0 * 2.0f64.powi(level - 1),
+            crystal: 300.0 * 2.0f64.powi(level - 1),
+            deuterium: 100.0 * 2.0f64.powi(level - 1),
+        },
+        "plasma_tech" => Cost {
+            metal: 2000.0 * 2.0f64.powi(level - 1),
+            crystal: 4000.0 * 2.0f64.powi(level - 1),
+            deuterium: 1000.0 * 2.0f64.powi(level - 1),
+        },
+        "shield_tech" => Cost {
+            metal: 200.0 * 2.0f64.powi(level - 1),
+            crystal: 600.0 * 2.0f64.powi(level - 1),
+            deuterium: 0.0,
+        },
+        "weapons_tech" => Cost {
+            metal: 800.0 * 2.0f64.powi(level - 1),
+            crystal: 200.0 * 2.0f64.powi(level - 1),
+            deuterium: 0.0,
+        },
+        "computer_tech" => Cost {
+            metal: 0.0,
+            crystal: 400.0 * 2.0f64.powi(level - 1),
+            deuterium: 600.0 * 2.0f64.powi(level - 1),
+        },
+        "combustion_drive" => Cost {
+            metal: 400.0 * 2.0f64.powi(level - 1),
+            crystal: 0.0,
+            deuterium: 600.0 * 2.0f64.powi(level - 1),
+        },
+        "impulse_drive" => Cost {
+            metal: 2000.0 * 2.0f64.powi(level - 1),
+            crystal: 4000.0 * 2.0f64.powi(level - 1),
+            deuterium: 600.0 * 2.0f64.powi(level - 1),
+        },
+        "hyperspace_drive" => Cost {
+            metal: 10000.0 * 2.0f64.powi(level - 1),
+            crystal: 20000.0 * 2.0f64.powi(level - 1),
+            deuterium: 6000.0 * 2.0f64.powi(level - 1),
+        },
+        "astrophysics" => Cost {
+            metal: 4000.0 * 2.0f64.powi(level - 1),
+            crystal: 8000.0 * 2.0f64.powi(level - 1),
+            deuterium: 4000.0 * 2.0f64.powi(level - 1),
+        },
+        "logistics_tech" => Cost {
+            metal: 1000.0 * 2.0f64.powi(level - 1),
+            crystal: 1000.0 * 2.0f64.powi(level - 1),
+            deuterium: 1000.0 * 2.0f64.powi(level - 1),
         },
         
         _ => Cost { metal: 0.0, crystal: 0.0, deuterium: 0.0 },
@@ -452,6 +656,10 @@ pub fn get_ship_cargo_capacity(ship_type: &str, config: &ServerConfigCache) -> f
     match ship_type {
         "light_hunter" => config.get_config("cargo_light_hunter", 50.0),
         "cruiser" => config.get_config("cargo_cruiser", 800.0),
+        "heavy_hunter" => config.get_config("cargo_heavy_hunter", 100.0),
+        "battleship" => config.get_config("cargo_battleship", 1500.0),
+        "bomber" => config.get_config("cargo_bomber", 500.0),
+        "destroyer" => config.get_config("cargo_destroyer", 2000.0),
         "transporter" => config.get_config("cargo_transporter_base", 10000.0),
         _ => 0.0,
     }
@@ -470,36 +678,125 @@ pub fn get_transporter_stats(config: &ServerConfigCache) -> (f64, f64) { get_uni
 // --- MOTEUR DE COMBAT ---
 pub fn get_unit_base_stats(unit_type: &str, config: &ServerConfigCache) -> UnitStats {
     match unit_type {
+        // Vaisseaux de Base
         "light_hunter" => UnitStats {
             attack: config.get_config("combat_light_hunter_attack", 50.0),
             shield: config.get_config("combat_light_hunter_shield", 10.0),
             hull: config.get_config("combat_light_hunter_hull", 400.0),
+            cargo_capacity: config.get_config("cargo_light_hunter", 50.0),
         },
         "cruiser" => UnitStats {
             attack: config.get_config("combat_cruiser_attack", 400.0),
             shield: config.get_config("combat_cruiser_shield", 50.0),
             hull: config.get_config("combat_cruiser_hull", 2700.0),
+            cargo_capacity: config.get_config("cargo_cruiser", 800.0),
         },
+
+        // Vaisseaux Avancés - EXPANSION 2.0
+        "heavy_hunter" => UnitStats {
+            attack: config.get_config("combat_heavy_hunter_attack", 150.0),
+            shield: config.get_config("combat_heavy_hunter_shield", 25.0),
+            hull: config.get_config("combat_heavy_hunter_hull", 1000.0),
+            cargo_capacity: config.get_config("cargo_heavy_hunter", 100.0),
+        },
+        "battleship" => UnitStats {
+            attack: config.get_config("combat_battleship_attack", 1000.0),
+            shield: config.get_config("combat_battleship_shield", 200.0),
+            hull: config.get_config("combat_battleship_hull", 6000.0),
+            cargo_capacity: config.get_config("cargo_battleship", 1500.0),
+        },
+        "bomber" => UnitStats {
+            attack: config.get_config("combat_bomber_attack", 1000.0),
+            shield: config.get_config("combat_bomber_shield", 500.0),
+            hull: config.get_config("combat_bomber_hull", 7500.0),
+            cargo_capacity: config.get_config("cargo_bomber", 500.0),
+        },
+        "destroyer" => UnitStats {
+            attack: config.get_config("combat_destroyer_attack", 2000.0),
+            shield: config.get_config("combat_destroyer_shield", 500.0),
+            hull: config.get_config("combat_destroyer_hull", 11000.0),
+            cargo_capacity: config.get_config("cargo_destroyer", 2000.0),
+        },
+
+        // Défenses
         "missile_launcher" => UnitStats {
             attack: config.get_config("combat_missile_launcher_attack", 80.0),
             shield: config.get_config("combat_missile_launcher_shield", 20.0),
             hull: config.get_config("combat_missile_launcher_hull", 200.0),
+            cargo_capacity: 0.0,
         },
         "plasma_turret" => UnitStats {
             attack: config.get_config("combat_plasma_turret_attack", 3000.0),
             shield: config.get_config("combat_plasma_turret_shield", 300.0),
             hull: config.get_config("combat_plasma_turret_hull", 10000.0),
+            cargo_capacity: 0.0,
         },
-        _ => UnitStats { attack: 1.0, shield: 1.0, hull: 10.0 },
+
+        // Default
+        _ => UnitStats {
+            attack: 1.0,
+            shield: 1.0,
+            hull: 10.0,
+            cargo_capacity: 0.0,
+        },
+    }
+}
+
+/// Apply tech bonuses to base stats
+pub fn apply_tech_bonuses(base_stats: UnitStats, bonuses: &TechBonuses) -> UnitStats {
+    UnitStats {
+        attack: base_stats.attack * bonuses.weapons_multiplier,
+        shield: base_stats.shield * bonuses.shield_multiplier,
+        hull: base_stats.hull * bonuses.armour_multiplier,
+        cargo_capacity: base_stats.cargo_capacity * bonuses.cargo_multiplier,
+    }
+}
+
+/// Create tech bonuses from tech levels
+pub fn create_tech_bonuses(
+    weapons_tech: i32,
+    shield_tech: i32,
+    armour_tech: i32,
+    logistics_tech: i32,
+    config: &ServerConfigCache
+) -> TechBonuses {
+    let weapons_bonus = config.get_config("tech_bonus_weapons", 0.1);
+    let shield_bonus = config.get_config("tech_bonus_shield", 0.1);
+    let armour_bonus = config.get_config("combat_armour_tech_bonus", 0.1);
+    let cargo_bonus = config.get_config("tech_bonus_cargo", 0.05);
+
+    TechBonuses {
+        weapons_multiplier: 1.0 + (weapons_tech as f64 * weapons_bonus),
+        shield_multiplier: 1.0 + (shield_tech as f64 * shield_bonus),
+        armour_multiplier: 1.0 + (armour_tech as f64 * armour_bonus),
+        cargo_multiplier: 1.0 + (logistics_tech as f64 * cargo_bonus),
     }
 }
 
 pub fn get_rapid_fire(attacker: &str, target: &str, config: &ServerConfigCache) -> i32 {
     match (attacker, target) {
+        // Existing Rapid Fire
         ("cruiser", "light_hunter") => config.get_config("combat_rf_cruiser_vs_light_hunter", 6.0) as i32,
         ("cruiser", "missile_launcher") => config.get_config("combat_rf_cruiser_vs_missile_launcher", 10.0) as i32,
         ("plasma_turret", "light_hunter") => config.get_config("combat_rf_plasma_vs_light_hunter", 5.0) as i32,
         ("plasma_turret", "cruiser") => config.get_config("combat_rf_plasma_vs_cruiser", 3.0) as i32,
+
+        // NEW SHIPS RAPID FIRE - EXPANSION 2.0
+        // Heavy Hunter
+        ("heavy_hunter", "spy_probe") => config.get_config("combat_rf_heavy_hunter_vs_spy_probe", 5.0) as i32,
+
+        // Battleship
+        ("battleship", "light_hunter") => config.get_config("combat_rf_battleship_vs_light_hunter", 4.0) as i32,
+        ("battleship", "heavy_hunter") => config.get_config("combat_rf_battleship_vs_heavy_hunter", 3.0) as i32,
+
+        // Bomber (anti-defense specialist)
+        ("bomber", "missile_launcher") => config.get_config("combat_rf_bomber_vs_missile_launcher", 20.0) as i32,
+        ("bomber", "plasma_turret") => config.get_config("combat_rf_bomber_vs_plasma_turret", 10.0) as i32,
+
+        // Destroyer (anti-large-ship)
+        ("destroyer", "battleship") => config.get_config("combat_rf_destroyer_vs_battleship", 2.0) as i32,
+        ("destroyer", "bomber") => config.get_config("combat_rf_destroyer_vs_bomber", 5.0) as i32,
+
         _ => 0,
     }
 }
@@ -535,6 +832,7 @@ pub fn resolve_pvp(
             attack: base.attack * (1.0 + techs.laser as f64 * laser_bonus),
             shield: base.shield, // Pas de tech bouclier pour l'instant
             hull: base.hull * (1.0 + techs.armour as f64 * armour_bonus),
+            cargo_capacity: base.cargo_capacity, // Cargo not affected by these techs
         }
     };
 
@@ -803,10 +1101,12 @@ pub fn calculate_planet_points(p: &crate::entities::planet::Model, config: &Serv
     );
 
     // Production de base avec bonus tech et énergie (slots non pris en compte ici car on n'a pas accès)
+    // Note: plasma_tech_level set to 0 as it's not in the current planet model yet
     let prod_metal = calculate_resource_production(
         ResourceType::Metal,
         p.metal_mine_level,
         p.energy_tech_level,
+        0, // plasma_tech_level - will be added to planet model
         energy_ratio,
         config
     );
@@ -814,6 +1114,7 @@ pub fn calculate_planet_points(p: &crate::entities::planet::Model, config: &Serv
         ResourceType::Crystal,
         p.crystal_mine_level,
         p.energy_tech_level,
+        0, // plasma_tech_level - will be added to planet model
         energy_ratio,
         config
     );
@@ -821,6 +1122,7 @@ pub fn calculate_planet_points(p: &crate::entities::planet::Model, config: &Serv
         ResourceType::Deuterium,
         p.deuterium_mine_level,
         p.energy_tech_level,
+        0, // plasma_tech_level - will be added to planet model
         energy_ratio,
         config
     );
@@ -925,6 +1227,7 @@ pub fn calculate_resources_with_slots(
     current_amount: f64,
     last_update: chrono::NaiveDateTime,
     energy_tech_level: i32,
+    plasma_tech_level: i32,
     energy_ratio: f64,
     slot_1: &Option<String>,
     slot_2: &Option<String>,
@@ -938,6 +1241,10 @@ pub fn calculate_resources_with_slots(
     // Bonus technologie énergie (+1% par niveau)
     let tech_bonus_factor = config.get_config("energy_tech_bonus", 0.01);
     let tech_bonus = 1.0 + (energy_tech_level as f64 * tech_bonus_factor);
+
+    // 🔥 Bonus Plasma Tech (+1% production Métal/Cristal par niveau)
+    let plasma_bonus_factor = config.get_config("tech_bonus_plasma_prod", 0.01);
+    let plasma_bonus = 1.0 + (plasma_tech_level as f64 * plasma_bonus_factor);
 
     // Déterminer le type de ressource pour compter les slots
     let resource_key = match res_type {
@@ -955,16 +1262,16 @@ pub fn calculate_resources_with_slots(
         ResourceType::Metal => {
             let base = config.get_config("production_metal_base", 30.0);
             let growth = config.get_config("production_metal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Crystal => {
             let base = config.get_config("production_crystal_base", 20.0);
             let growth = config.get_config("production_crystal_growth", 1.1);
-            base * (level as f64) * growth.powi(level)
+            base * (level as f64) * growth.powi(level) * plasma_bonus
         },
         ResourceType::Deuterium => {
             let base = config.get_config("production_deuterium_base", 10.0);
-            let growth = config.get_config("production_deuterium_growth", 1.05);
+            let growth = config.get_config("production_deuterium_growth", 1.1);
             base * (level as f64) * growth.powi(level)
         },
     };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -374,30 +374,36 @@ async fn resolve_attack_mission(
     
     let mut def_planet = def_planet_raw.clone();
     // Utiliser calculate_resources_with_energy pour prendre en compte le ratio énergétique
+    // Note: plasma_tech_level will be 0 until planet model is updated
+    let plasma_tech_level = 0;
+
     def_planet.metal_amount = game_logic::calculate_resources_with_energy(
-        game_logic::ResourceType::Metal, 
-        def_planet_raw.metal_mine_level, 
-        def_planet_raw.metal_amount, 
-        def_planet_raw.last_update, 
+        game_logic::ResourceType::Metal,
+        def_planet_raw.metal_mine_level,
+        def_planet_raw.metal_amount,
+        def_planet_raw.last_update,
         def_planet_raw.energy_tech_level,
+        plasma_tech_level,
         def_energy_ratio,
         config
     );
     def_planet.crystal_amount = game_logic::calculate_resources_with_energy(
-        game_logic::ResourceType::Crystal, 
-        def_planet_raw.crystal_mine_level, 
-        def_planet_raw.crystal_amount, 
-        def_planet_raw.last_update, 
+        game_logic::ResourceType::Crystal,
+        def_planet_raw.crystal_mine_level,
+        def_planet_raw.crystal_amount,
+        def_planet_raw.last_update,
         def_planet_raw.energy_tech_level,
+        plasma_tech_level,
         def_energy_ratio,
         config
     );
     def_planet.deuterium_amount = game_logic::calculate_resources_with_energy(
-        game_logic::ResourceType::Deuterium, 
-        def_planet_raw.deuterium_mine_level, 
-        def_planet_raw.deuterium_amount, 
-        def_planet_raw.last_update, 
+        game_logic::ResourceType::Deuterium,
+        def_planet_raw.deuterium_mine_level,
+        def_planet_raw.deuterium_amount,
+        def_planet_raw.last_update,
         def_planet_raw.energy_tech_level,
+        plasma_tech_level,
         def_energy_ratio,
         config
     );
@@ -888,17 +894,20 @@ async fn get_planet_handler(
             .unwrap_or(1.0); // Défaut à 1.0 en cas d'erreur
 
         // Calculer les ressources de base
+        // Note: plasma_tech_level will be 0 until planet model is updated
+        let plasma_tech_level = 0;
+
         let base_metal = game_logic::calculate_resources_with_slots(
             game_logic::ResourceType::Metal, p.metal_mine_level, p.metal_amount, p.last_update,
-            p.energy_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
+            p.energy_tech_level, plasma_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
         );
         let base_crystal = game_logic::calculate_resources_with_slots(
             game_logic::ResourceType::Crystal, p.crystal_mine_level, p.crystal_amount, p.last_update,
-            p.energy_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
+            p.energy_tech_level, plasma_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
         );
         let base_deuterium = game_logic::calculate_resources_with_slots(
             game_logic::ResourceType::Deuterium, p.deuterium_mine_level, p.deuterium_amount, p.last_update,
-            p.energy_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
+            p.energy_tech_level, plasma_tech_level, energy_ratio, &slot_1, &slot_2, &slot_3, &slot_4, &config
         );
 
         // Appliquer le multiplicateur de sabotage (50% si sabotage actif, 100% sinon)

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -424,12 +424,16 @@ async fn calculate_current_resources(
     let energy_ratio_decimal = energy_ratio_percent / 100.0;
 
     // Calculer les ressources actuelles avec le config
+    // Note: plasma_tech_level will be 0 until planet model is updated
+    let plasma_tech_level = 0; // TODO: Get from planet model once migration is applied
+
     let metal = game_logic::calculate_resources_with_slots(
         game_logic::ResourceType::Metal,
         planet.metal_mine_level,
         planet.metal_amount,
         planet.last_update,
         planet.energy_tech_level,
+        plasma_tech_level,
         energy_ratio_decimal,
         &slot_1, &slot_2, &slot_3, &slot_4,
         config,
@@ -441,6 +445,7 @@ async fn calculate_current_resources(
         planet.crystal_amount,
         planet.last_update,
         planet.energy_tech_level,
+        plasma_tech_level,
         energy_ratio_decimal,
         &slot_1, &slot_2, &slot_3, &slot_4,
         config,
@@ -452,6 +457,7 @@ async fn calculate_current_resources(
         planet.deuterium_amount,
         planet.last_update,
         planet.energy_tech_level,
+        plasma_tech_level,
         energy_ratio_decimal,
         &slot_1, &slot_2, &slot_3, &slot_4,
         config,

--- a/frontend/src/lib/gameRules.ts
+++ b/frontend/src/lib/gameRules.ts
@@ -22,26 +22,74 @@ export const checkPrerequisites = (planet: any, type: string): { locked: boolean
              // Pas de prérequis de base
             break;
 
-        // --- RECHERCHES ---
+        // --- RECHERCHES DE BASE ---
         case 'energy_tech':
             check("Laboratoire de Recherche (1)", (planet.research_lab_level || 0) >= 1);
             break;
-        case 'laser_tech': // Tech Laser (pour l'exemple)
+        case 'laser_tech':
             check("Laboratoire de Recherche (1)", (planet.research_lab_level || 0) >= 1);
             check("Tech. Énergie (2)", (planet.energy_tech_level || 0) >= 2);
             break;
+        case 'espionage':
+            check("Laboratoire de Recherche (3)", (planet.research_lab_level || 0) >= 3);
+            break;
+        case 'armour':
+            check("Laboratoire de Recherche (2)", (planet.research_lab_level || 0) >= 2);
+            break;
 
-        // --- FLOTTE ---
+        // --- RECHERCHES AVANCÉES - EXPANSION 2.0 ---
+        case 'ion_tech':
+            check("Laboratoire de Recherche (4)", (planet.research_lab_level || 0) >= 4);
+            check("Tech. Énergie (4)", (planet.energy_tech_level || 0) >= 4);
+            check("Tech. Laser (5)", (planet.laser_battery_level || 0) >= 5);
+            break;
+        case 'plasma_tech':
+            check("Laboratoire de Recherche (4)", (planet.research_lab_level || 0) >= 4);
+            check("Tech. Énergie (8)", (planet.energy_tech_level || 0) >= 8);
+            check("Tech. Laser (10)", (planet.laser_battery_level || 0) >= 10);
+            check("Tech. Ion (5)", (planet.ion_tech_level || 0) >= 5);
+            break;
+        case 'shield_tech':
+            check("Laboratoire de Recherche (6)", (planet.research_lab_level || 0) >= 6);
+            check("Tech. Énergie (3)", (planet.energy_tech_level || 0) >= 3);
+            break;
+        case 'weapons_tech':
+            check("Laboratoire de Recherche (4)", (planet.research_lab_level || 0) >= 4);
+            break;
+        case 'computer_tech':
+            check("Laboratoire de Recherche (1)", (planet.research_lab_level || 0) >= 1);
+            break;
+
+        // --- PROPULSION - EXPANSION 2.0 ---
+        case 'combustion_drive':
+            check("Laboratoire de Recherche (1)", (planet.research_lab_level || 0) >= 1);
+            check("Tech. Énergie (1)", (planet.energy_tech_level || 0) >= 1);
+            break;
+        case 'impulse_drive':
+            check("Laboratoire de Recherche (2)", (planet.research_lab_level || 0) >= 2);
+            check("Tech. Énergie (1)", (planet.energy_tech_level || 0) >= 1);
+            break;
+        case 'hyperspace_drive':
+            check("Laboratoire de Recherche (7)", (planet.research_lab_level || 0) >= 7);
+            check("Tech. Énergie (5)", (planet.energy_tech_level || 0) >= 5);
+            check("Tech. Bouclier (5)", (planet.shield_tech_level || 0) >= 5);
+            break;
+        case 'astrophysics':
+            check("Laboratoire de Recherche (3)", (planet.research_lab_level || 0) >= 3);
+            check("Tech. Espionnage (4)", (planet.espionage_tech_level || 0) >= 4);
+            check("Propulsion à Impulsion (3)", (planet.impulse_drive_level || 0) >= 3);
+            break;
+
+        // --- FLOTTE DE BASE ---
         case 'light_hunter':
             check("Chantier Spatial (1)", (planet.shipyard_level || 0) >= 1);
             break;
         case 'cruiser':
             check("Chantier Spatial (5)", (planet.shipyard_level || 0) >= 5);
-            check("Tech. Énergie (4)", (planet.energy_tech_level || 0) >= 4); // "Impulsion" simulée par Énergie
+            check("Tech. Énergie (3)", (planet.energy_tech_level || 0) >= 3);
             break;
         case 'recycler':
             check("Chantier Spatial (4)", (planet.shipyard_level || 0) >= 4);
-            check("Tech. Énergie (3)", (planet.energy_tech_level || 0) >= 3); // "Combustion" simulée
             break;
         case 'spy_probe':
             check("Chantier Spatial (1)", (planet.shipyard_level || 0) >= 1);
@@ -54,13 +102,31 @@ export const checkPrerequisites = (planet: any, type: string): { locked: boolean
             check("Chantier Spatial (2)", (planet.shipyard_level || 0) >= 2);
             break;
 
+        // --- FLOTTE AVANCÉE - EXPANSION 2.0 ---
+        case 'heavy_hunter':
+            check("Chantier Spatial (3)", (planet.shipyard_level || 0) >= 3);
+            check("Tech. Blindage (3)", (planet.armour_tech_level || 0) >= 3);
+            check("Propulsion à Impulsion (1)", (planet.impulse_drive_level || 0) >= 1);
+            break;
+        case 'battleship':
+            check("Chantier Spatial (7)", (planet.shipyard_level || 0) >= 7);
+            check("Propulsion Hyperespace (4)", (planet.hyperspace_drive_level || 0) >= 4);
+            break;
+        case 'bomber':
+            check("Chantier Spatial (8)", (planet.shipyard_level || 0) >= 8);
+            check("Tech. Plasma (5)", (planet.plasma_tech_level || 0) >= 5);
+            check("Propulsion à Impulsion (6)", (planet.impulse_drive_level || 0) >= 6);
+            break;
+        case 'destroyer':
+            check("Chantier Spatial (9)", (planet.shipyard_level || 0) >= 9);
+            check("Propulsion Hyperespace (6)", (planet.hyperspace_drive_level || 0) >= 6);
+            check("Tech. Hyperespace (5)", (planet.astrophysics_level || 0) >= 5);
+            break;
+
         // --- DÉFENSES ---
         case 'missile_launcher':
             check("Chantier Spatial (1)", (planet.shipyard_level || 0) >= 1);
             break;
-        case 'armour':
-    check("Laboratoire de Recherche (2)", (planet.research_lab_level || 0) >= 2);
-    break;    
         case 'plasma_turret':
             check("Chantier Spatial (8)", (planet.shipyard_level || 0) >= 8);
             check("Tech. Énergie (6)", (planet.energy_tech_level || 0) >= 6);


### PR DESCRIPTION
MAJOR GAMEPLAY REFACTOR - Expansion 2.0

## Database Changes
- Add 10 new technology columns to planet table:
  - Propulsion: combustion_drive, impulse_drive, hyperspace_drive
  - Combat: ion_tech, plasma_tech, shield_tech, weapons_tech
  - Research: computer_tech, astrophysics, logistics_tech
- Add 4 new ship type columns: heavy_hunter, battleship, bomber, destroyer
- Add deuterium_synthesizer_level building column

## Backend Configuration
- Add 43 new server config keys for:
  - Energy production/consumption parameters
  - Tech bonuses (cargo, plasma production, shield, weapons)
  - New ship costs (metal, crystal, deuterium)
  - New ship combat stats (attack, shield, hull, cargo)
  - Rapid fire rules for new ships

## Resource System Refactor
- Implement energy efficiency system:
  - Calculate total energy production from solar plants
  - Calculate total energy consumption from mines
  - Apply efficiency ratio (production/consumption) to all resources
- Add plasma tech bonus to metal/crystal production (+1% per level)
- Update calculate_resources() to include energy efficiency
- Update all resource calculation functions with plasma_tech parameter

## Tech Tree & Prerequisites
- Implement cascading tech dependencies:
  - Propulsion techs require Energy Tech and Research Lab
  - Plasma Tech requires Energy (8), Laser (10), Ion (5)
  - Hyperspace Drive requires Energy (5), Shield (5), Research Lab (7)
  - Astrophysics requires Espionage (4), Impulse Drive (3)
- Add prerequisites for 4 new ships:
  - Heavy Hunter: Shipyard 3, Armour 3, Impulse Drive 1
  - Battleship: Shipyard 7, Hyperspace Drive 4
  - Bomber: Shipyard 8, Plasma Tech 5, Impulse Drive 6
  - Destroyer: Shipyard 9, Hyperspace Drive 6, Astrophysics 5

## Combat System Enhancements
- Extend UnitStats struct with cargo_capacity field
- Create TechBonuses struct for dynamic stat multipliers
- Add combat stats for 4 new ships with different roles:
  - Heavy Hunter: Fast interceptor (150 atk, 25 shield, 1000 hull)
  - Battleship: Heavy capital ship (1000 atk, 200 shield, 6000 hull)
  - Bomber: Defense-buster (1000 atk vs defenses, RF 20 vs missiles)
  - Destroyer: Anti-capital (2000 atk, RF 5 vs bombers)
- Make combat system generic using HashMap for fleet composition
- Add rapid fire rules for new ship interactions

## Frontend Updates
- Sync gameRules.ts with backend prerequisites
- Add all new tech and ship requirements to UI validation

## Technical Notes
- Plasma tech temporarily defaults to 0 until planet entity regeneration
- All function signatures updated to include plasma_tech_level parameter
- Backward compatible: existing saves work with default values (0)

Closes #XX