### PR TITLE
feat(backend): Enable expedition_v2_handler with dynamic combat system

### DIFF
--- a/backend/src/combat.rs
+++ b/backend/src/combat.rs
@@ -199,7 +199,6 @@ pub async fn resolve_expedition_combat(
     db: &DatabaseConnection,
     player_ships: HashMap<String, i32>,
 ) -> Result<CombatReport, sea_orm::DbErr> {
-    let mut rng = rand::thread_rng();
     let mut logs = Vec::new();
 
     // Load ship stats and rapid fire rules from database
@@ -213,7 +212,7 @@ pub async fn resolve_expedition_combat(
     }
 
     // 2. Generate pirate fleet (scaling factor 50% to 110% of player strength)
-    let scaling_factor = rng.gen_range(0.5..1.1);
+    let scaling_factor = 0.5 + (rand::random::<f64>() * 0.6); // Random value between 0.5 and 1.1
     let mut pirate_fleet = Fleet::new();
 
     // Pirates mirror player fleet composition with scaling
@@ -236,7 +235,8 @@ pub async fn resolve_expedition_combat(
 
     // Ensure pirates always have at least some ships
     if pirate_fleet.is_destroyed() {
-        pirate_fleet.set_ship_count("light_hunter", rng.gen_range(1..3));
+        let count = 1 + (rand::random::<f64>() * 2.0).floor() as i32; // Random 1 or 2
+        pirate_fleet.set_ship_count("light_hunter", count);
     }
 
     logs.push(format!(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -45,8 +45,8 @@ use websocket::WsState;
 
 // ✅ IMPORTS EXPLICITES
 use entities::{
-    prelude::{Planet, User, CombatLog, FleetMission, TransportLog, ConstructionQueue, MarketListing, MarketTransaction, MarketPriceHistory},
-    planet, user, combat_log, fleet_mission, transport_log, construction_queue, market_listing, market_transaction, market_price_history
+    prelude::{Planet, User, CombatLog, FleetMission, TransportLog, ConstructionQueue, MarketListing, MarketTransaction, MarketPriceHistory, ShipType, PlanetShip},
+    planet, user, combat_log, fleet_mission, transport_log, construction_queue, market_listing, market_transaction, market_price_history, planet_ship, ship_type
 };
 
 #[derive(Serialize, Clone)]
@@ -4283,14 +4283,12 @@ async fn update_planet_ships_after_combat(
 }
 
 /// POST /planets/:id/expedition-v2 - New expedition handler using dynamic combat system
+#[axum::debug_handler]
 async fn expedition_v2_handler(
     Path(id): Path<Uuid>,
     State(state): State<AppState>,
     Json(payload): Json<ExpeditionPayloadV2>,
 ) -> impl IntoResponse {
-    use entities::prelude::*;
-    use entities::{planet_ship, ship_type};
-
     // Get planet
     let planet = match Planet::find_by_id(id).one(&state.db).await {
         Ok(Some(p)) => p,
@@ -4350,7 +4348,7 @@ async fn expedition_v2_handler(
     let speed_factor = config.speed_factor;
 
     // Determine if combat occurs
-    let combat_triggered = rand::thread_rng().gen_bool(combat_chance);
+    let combat_triggered = rand::random::<f64>() < combat_chance;
 
     let mut logs = Vec::new();
     let (final_metal, final_crystal, final_deuterium, winner) = if combat_triggered {


### PR DESCRIPTION
Fixed the Axum Handler trait bound issue by replacing thread_rng() with thread-safe random number generation using rand::random().

Changes:
- Added ShipType and PlanetShip to global imports in main.rs
- Removed local 'use' statements from expedition_v2_handler
- Replaced thread_rng() with rand::random() in combat.rs for Send compatibility
- Added #[axum::debug_handler] attribute for better error diagnostics

The expedition_v2_handler now:
- Validates fleet composition against planet_ships relational table
- Uses dynamic combat system from combat.rs
- Supports any ship type without code changes
- Properly implements IntoResponse trait for Axum routing

Fixes: E0277 trait bound error (Rc<UnsafeCell<...>> not Send between threads)