### PR TITLE
fix: Fix database schema mismatches in Expansion 2.0 entities

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -50,6 +50,7 @@ mod m20260125_100001_create_tech_tree_system;
 mod m20260125_100002_seed_tech_tree_data;
 mod m20260125_100003_migrate_planet_data;
 mod m20260125_100004_add_research_tracking_columns;
+mod m20260125_100005_add_build_time_columns;
 
 pub struct Migrator;
 
@@ -107,6 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260125_100002_seed_tech_tree_data::Migration),
             Box::new(m20260125_100003_migrate_planet_data::Migration),
             Box::new(m20260125_100004_add_research_tracking_columns::Migration),
+            Box::new(m20260125_100005_add_build_time_columns::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260125_100005_add_build_time_columns.rs
+++ b/backend/migration/src/m20260125_100005_add_build_time_columns.rs
@@ -1,0 +1,87 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add build_time_seconds to ship_types table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("ship_types"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("build_time_seconds"))
+                            .integer()
+                            .not_null()
+                            .default(300), // 5 minutes default
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Add base_time_seconds to technologies table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("technologies"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("base_time_seconds"))
+                            .integer()
+                            .not_null()
+                            .default(600), // 10 minutes default
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Update ship_types with calculated build times based on costs
+        manager.exec_stmt(
+            Query::update()
+                .table(Alias::new("ship_types"))
+                .value(
+                    Alias::new("build_time_seconds"),
+                    Expr::cust("CAST((base_cost_metal + base_cost_crystal) / 2500.0 * 3600.0 AS INTEGER)"),
+                )
+                .to_owned(),
+        ).await?;
+
+        // Update technologies with calculated base times based on costs
+        manager.exec_stmt(
+            Query::update()
+                .table(Alias::new("technologies"))
+                .value(
+                    Alias::new("base_time_seconds"),
+                    Expr::cust("CAST((base_cost_metal + base_cost_crystal) / 2500.0 * 3600.0 AS INTEGER)"),
+                )
+                .to_owned(),
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Remove build_time_seconds from ship_types
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("ship_types"))
+                    .drop_column(Alias::new("build_time_seconds"))
+                    .to_owned(),
+            )
+            .await?;
+
+        // Remove base_time_seconds from technologies
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("technologies"))
+                    .drop_column(Alias::new("base_time_seconds"))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/backend/src/combat.rs
+++ b/backend/src/combat.rs
@@ -63,8 +63,8 @@ pub async fn load_rapid_fire_cache(db: &DatabaseConnection) -> Result<RapidFireC
     for rule in all_rules {
         // Get ship keys from ship_type_id
         if let (Some(attacker), Some(target)) = (
-            ShipType::find_by_id(rule.attacker_ship_id).one(db).await?,
-            ShipType::find_by_id(rule.target_id).one(db).await?,
+            ShipType::find_by_id(rule.attacker_ship_type_id).one(db).await?,
+            ShipType::find_by_id(rule.target_ship_type_id).one(db).await?,
         ) {
             cache.insert(
                 (attacker.ship_key, target.ship_key),

--- a/backend/src/entities/rapid_fire_rule.rs
+++ b/backend/src/entities/rapid_fire_rule.rs
@@ -6,12 +6,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "rapid_fire_rules")]
 pub struct Model {
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub attacker_ship_id: i32,
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub target_type: String,
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub target_id: i32,
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub attacker_ship_type_id: i32,
+    pub target_ship_type_id: i32,
     pub rapid_fire_value: i32,
 }
 
@@ -19,12 +17,20 @@ pub struct Model {
 pub enum Relation {
     #[sea_orm(
         belongs_to = "super::ship_type::Entity",
-        from = "Column::AttackerShipId",
+        from = "Column::AttackerShipTypeId",
         to = "super::ship_type::Column::Id",
         on_update = "Cascade",
         on_delete = "Cascade"
     )]
     AttackerShip,
+    #[sea_orm(
+        belongs_to = "super::ship_type::Entity",
+        from = "Column::TargetShipTypeId",
+        to = "super::ship_type::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    TargetShip,
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/entities/ship_type.rs
+++ b/backend/src/entities/ship_type.rs
@@ -10,18 +10,26 @@ pub struct Model {
     pub id: i32,
     #[sea_orm(unique)]
     pub ship_key: String,
+    #[sea_orm(column_name = "name")]
     pub display_name: String,
-    pub description: Option<String>,
+    pub category: String,
+    #[sea_orm(column_name = "base_cost_metal")]
     pub cost_metal: i32,
+    #[sea_orm(column_name = "base_cost_crystal")]
     pub cost_crystal: i32,
+    #[sea_orm(column_name = "base_cost_deuterium")]
     pub cost_deuterium: i32,
     pub build_time_seconds: i32,
     pub attack: i32,
     pub shield: i32,
     pub hull: i32,
     pub cargo_capacity: i32,
+    #[sea_orm(column_name = "speed")]
     pub base_speed: i32,
     pub fuel_consumption: i32,
+    pub shipyard_required: i32,
+    pub description: Option<String>,
+    pub created_at: Option<DateTime>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/entities/technology.rs
+++ b/backend/src/entities/technology.rs
@@ -10,13 +10,17 @@ pub struct Model {
     pub id: i32,
     #[sea_orm(unique)]
     pub tech_key: String,
+    #[sea_orm(column_name = "name")]
     pub display_name: String,
-    pub description: Option<String>,
+    pub category: String,
     pub base_cost_metal: i32,
     pub base_cost_crystal: i32,
     pub base_cost_deuterium: i32,
     pub base_time_seconds: i32,
     pub cost_multiplier: f64,
+    pub research_lab_required: i32,
+    pub description: Option<String>,
+    pub created_at: Option<DateTime>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
Fixed critical database errors preventing expedition-v2 and tech-tree endpoints from working.

**Entity Fixes:**
- rapid_fire_rule: Corrected column names to match migration schema
  - attacker_ship_id → attacker_ship_type_id
  - target_type/target_id → target_ship_type_id
  - Added missing id primary key column

- ship_type: Aligned column names with database
  - display_name → name (with column_name annotation)
  - cost_* → base_cost_* (with column_name annotation)
  - base_speed → speed (with column_name annotation)
  - Added missing columns: category, shipyard_required, created_at
  - Added build_time_seconds column

- technology: Fixed column mismatches
  - display_name → name (with column_name annotation)
  - Added missing columns: category, research_lab_required, base_time_seconds, created_at

**New Migration:**
- m20260125_100005_add_build_time_columns.rs
  - Adds build_time_seconds to ship_types
  - Adds base_time_seconds to technologies
  - Auto-calculates initial values from costs

**Code Updates:**
- combat.rs: Updated rapid_fire cache loading to use correct column names

This resolves "Database error" issues in expedition-v2 and tech-tree endpoints.