### PR TITLE
fix: Add missing building_count and build_end_time columns to planet_…

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -51,6 +51,7 @@ mod m20260125_100002_seed_tech_tree_data;
 mod m20260125_100003_migrate_planet_data;
 mod m20260125_100004_add_research_tracking_columns;
 mod m20260125_100005_add_build_time_columns;
+mod m20260125_100006_add_ship_building_columns;
 
 pub struct Migrator;
 
@@ -109,6 +110,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260125_100003_migrate_planet_data::Migration),
             Box::new(m20260125_100004_add_research_tracking_columns::Migration),
             Box::new(m20260125_100005_add_build_time_columns::Migration),
+            Box::new(m20260125_100006_add_ship_building_columns::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260125_100006_add_ship_building_columns.rs
+++ b/backend/migration/src/m20260125_100006_add_ship_building_columns.rs
@@ -1,0 +1,78 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add building_count and build_end_time columns to planet_ships table
+        // These columns track in-progress ship construction
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("planet_ships"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("building_count"))
+                            .integer()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("planet_ships"))
+                    .add_column(
+                        ColumnDef::new("build_end_time")
+                            .timestamp()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Also need to add updated_at column if it doesn't exist
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("planet_ships"))
+                    .add_column_if_not_exists(
+                        ColumnDef::new("updated_at")
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Remove building_count and build_end_time columns
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("planet_ships"))
+                    .drop_column(Alias::new("build_end_time"))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("planet_ships"))
+                    .drop_column(Alias::new("building_count"))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
…ships

Added migration m20260125_100006_add_ship_building_columns.rs to create:
- building_count: Tracks quantity of ships currently being built
- build_end_time: Timestamp when ship construction completes
- updated_at: Standard tracking column for table updates

These columns are required by the ship building system in build_ships_handler and update_planet_ships_after_combat functions. Without these columns, the expedition-v2 endpoint fails with "Database error" when trying to query planet_ships records.

This resolves the remaining expedition-v2 database error.