### PR TITLE
feat: Update Shipyard and Defenses with dynamic tech requirements

### DIFF
--- a/frontend/src/components/Defenses.tsx
+++ b/frontend/src/components/Defenses.tsx
@@ -1,61 +1,101 @@
 import { useState, useEffect } from 'react';
-import { Shield, Zap, Target, Crosshair, Timer, Terminal } from "lucide-react";
+import { Shield, Zap, Target, Crosshair, Timer, Terminal, Lock, CheckCircle2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { apiUrl } from '@/config/api';
-import { useUnitCosts } from '@/hooks/useUnitCosts';
 import { toast } from "sonner";
-import { checkPrerequisites } from "@/lib/gameRules";
 import { GameImage } from '@/components/ui/game-image';
 import { getDefenseImage } from '@/lib/images';
 
+interface DefenseRequirement {
+  requirement_type: string;
+  tech_key?: string;
+  tech_name?: string;
+  building_key?: string;
+  building_name?: string;
+  required_level: number;
+  current_level: number;
+  met: boolean;
+}
+
+interface DefenseTypeInfo {
+  id: number;
+  defense_key: string;
+  name: string;
+  description: string | null;
+  base_cost_metal: number;
+  base_cost_crystal: number;
+  base_cost_deuterium: number;
+  base_time_seconds: number;
+  attack: number;
+  shield: number;
+  hull: number;
+  current_count: number;
+  requirements: DefenseRequirement[];
+}
+
 export default function Defenses({ planet, onBuild }: { planet: any, onBuild: () => void }) {
-  const [selected, setSelected] = useState<string>('missile_launcher');
+  const [selected, setSelected] = useState<string>('');
   const [qty, setQty] = useState(1);
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
-  
-  // ✅ AJOUT : Fetch des coûts depuis le backend
-  const { costs, loading } = useUnitCosts();
+  const [defenseTypes, setDefenseTypes] = useState<DefenseTypeInfo[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  // ✅ Configuration des défenses (sans les coûts hardcodés)
-  const DEFENSE_CONFIG = {
-    missile_launcher: {
-      name: 'Lanceur de Missiles',
-      tier: 'Défense Légère',
-      desc: 'Batterie sol-air standard. Efficace en grand nombre.',
-      time: 10,
-      atk: 80,
-      def: 200,
-      color: 'text-blue-400',
-      border: 'border-blue-500',
-      glow: 'shadow-[0_0_20px_rgba(96,165,250,0.5)]',
-      bg: 'bg-blue-950/20'
-    },
-    plasma_turret: {
-      name: 'Tourelle Plasma',
-      tier: 'Artillerie Lourde',
-      desc: 'Projection de plasma surchauffé capable de percer les croiseurs.',
-      time: 120,
-      atk: 3000,
-      def: 10000,
-      color: 'text-pink-500',
-      border: 'border-pink-600',
-      glow: 'shadow-[0_0_20px_rgba(236,72,153,0.5)]',
-      bg: 'bg-pink-950/20'
+  useEffect(() => {
+    const fetchDefenseTypes = async () => {
+      const token = localStorage.getItem('token');
+      try {
+        const response = await fetch(apiUrl(`/planets/${planet.id}/defense-types`), {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (response.ok) {
+          const data = await response.json();
+          const types = data.defense_types || [];
+          setDefenseTypes(types);
+          if (types.length > 0 && !selected) {
+            setSelected(types[0].defense_key);
+          }
+        }
+      } catch (e) {
+        console.error("Failed to fetch defense types:", e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchDefenseTypes();
+  }, [planet.id]);
+
+  const getDefenseTheme = (defense_key: string) => {
+    // Color themes based on defense type
+    if (defense_key.includes('laser')) {
+      return { color: 'text-red-400', border: 'border-red-500', glow: 'shadow-[0_0_20px_rgba(248,113,113,0.5)]', bg: 'bg-red-950/20', tier: 'Défense Laser' };
     }
+    if (defense_key.includes('plasma')) {
+      return { color: 'text-pink-500', border: 'border-pink-600', glow: 'shadow-[0_0_20px_rgba(236,72,153,0.5)]', bg: 'bg-pink-950/20', tier: 'Artillerie Lourde' };
+    }
+    if (defense_key.includes('ion')) {
+      return { color: 'text-purple-400', border: 'border-purple-500', glow: 'shadow-[0_0_20px_rgba(192,132,252,0.5)]', bg: 'bg-purple-950/20', tier: 'Défense Ionique' };
+    }
+    if (defense_key.includes('missile')) {
+      return { color: 'text-blue-400', border: 'border-blue-500', glow: 'shadow-[0_0_20px_rgba(96,165,250,0.5)]', bg: 'bg-blue-950/20', tier: 'Défense Légère' };
+    }
+    if (defense_key.includes('shield')) {
+      return { color: 'text-cyan-400', border: 'border-cyan-500', glow: 'shadow-[0_0_20px_rgba(34,211,238,0.5)]', bg: 'bg-cyan-950/20', tier: 'Bouclier' };
+    }
+    return { color: 'text-slate-400', border: 'border-slate-500', glow: 'shadow-[0_0_20px_rgba(148,163,184,0.5)]', bg: 'bg-slate-950/20', tier: 'Défense' };
   };
 
   useEffect(() => {
     const defenseQueue = planet?.constructions?.find(
-      (c: any) => c.building_type === 'missile_launcher' || c.building_type === 'plasma_turret'
+      (c: any) => defenseTypes.some(d => d.defense_key === c.building_type)
     );
-    
+
     if (defenseQueue) {
       const interval = setInterval(() => {
         const end = new Date(defenseQueue.end_time).getTime();
         const now = Date.now();
         const diff = Math.max(0, Math.floor((end - now) / 1000));
-        
+
         setTimeLeft(diff);
         if (diff <= 0) {
           clearInterval(interval);
@@ -66,9 +106,12 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
     } else {
       setTimeLeft(null);
     }
-  }, [planet?.constructions, onBuild]);
+  }, [planet?.constructions, onBuild, defenseTypes]);
 
   const startBuild = async () => {
+    const selectedDefense = defenseTypes.find(d => d.defense_key === selected);
+    if (!selectedDefense) return;
+
     try {
       const res = await fetch(apiUrl(`/planets/${planet.id}/build-fleet/${selected}/${qty}`), {
         method: 'POST',
@@ -76,7 +119,7 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
       });
 
       if (res.ok) {
-        toast.success(`Construction lancée : ${qty}x ${selectedConfig.name}`);
+        toast.success(`Construction lancée : ${qty}x ${selectedDefense.name}`);
         onBuild();
       } else if (res.status === 403) {
         toast.error("Prérequis non satisfaits");
@@ -93,25 +136,26 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
     }
   };
 
-  // ✅ Afficher un loader pendant le chargement des coûts
-  if (loading || !costs) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-500"></div>
+        <div className="text-slate-400 animate-pulse">Chargement des systèmes défensifs...</div>
       </div>
     );
   }
 
-  const selectedConfig = DEFENSE_CONFIG[selected as keyof typeof DEFENSE_CONFIG];
-  const selectedCost = costs[selected as keyof typeof costs];
+  const selectedDefense = defenseTypes.find(d => d.defense_key === selected);
+  if (!selectedDefense) return null;
 
-  const totalM = selectedCost.metal * qty;
-  const totalC = selectedCost.crystal * qty;
+  const selectedTheme = getDefenseTheme(selectedDefense.defense_key);
+
+  const totalM = selectedDefense.base_cost_metal * qty;
+  const totalC = selectedDefense.base_cost_crystal * qty;
   const canAfford = planet.metal_amount >= totalM && planet.crystal_amount >= totalC;
   const isBusy = timeLeft !== null && timeLeft > 0;
 
   // Check prerequisites
-  const { locked: isLocked, requirements } = checkPrerequisites(planet, selected);
+  const isLocked = selectedDefense.requirements.some(req => !req.met);
   const canBuild = !isBusy && canAfford && !isLocked;
 
   const formatTime = (seconds: number) => {
@@ -128,30 +172,36 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
       
       {/* GAUCHE : SÉLECTEUR & COMMANDE */}
       <div className="lg:col-span-2 space-y-6">
-        <div className="grid grid-cols-2 gap-4">
-          {Object.entries(DEFENSE_CONFIG).map(([id, config]) => {
-            const isSelected = selected === id;
-            const cost = costs[id as keyof typeof costs];
-            
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {defenseTypes.map((defense) => {
+            const isSelected = selected === defense.defense_key;
+            const theme = getDefenseTheme(defense.defense_key);
+            const locked = defense.requirements.some(req => !req.met);
+
             return (
               <button
-                key={id}
-                onClick={() => setSelected(id)}
+                key={defense.id}
+                onClick={() => setSelected(defense.defense_key)}
                 className={`relative group overflow-hidden rounded-xl border transition-all duration-500 p-4 text-left h-32 flex flex-col justify-between hover:-translate-y-1 hover:shadow-2xl card-depth animate-fade-in
-                  ${isSelected ? `${config.bg} ${config.border} ${config.glow} scale-105 z-10` : 'bg-black/40 border-white/10 opacity-70 hover:opacity-100'}`}
+                  ${locked ? 'bg-black/40 border-red-900/50 opacity-50' : isSelected ? `${theme.bg} ${theme.border} ${theme.glow} scale-105 z-10` : 'bg-black/40 border-white/10 opacity-70 hover:opacity-100'}`}
               >
+                 {locked && (
+                   <div className="absolute top-2 right-2">
+                     <Lock size={14} className="text-red-500" />
+                   </div>
+                 )}
                  <div className="flex justify-between items-start">
                     <div>
-                        <span className={`text-[9px] font-black uppercase tracking-widest ${config.color}`}>{config.tier}</span>
-                        <h3 className="text-sm font-black uppercase text-white">{config.name}</h3>
+                        <span className={`text-[9px] font-black uppercase tracking-widest ${theme.color}`}>{theme.tier}</span>
+                        <h3 className="text-sm font-black uppercase text-white">{defense.name}</h3>
                     </div>
-                    {id === 'plasma_turret' ? <Zap size={20} className={`${config.color} group-hover:scale-110 transition-transform duration-300`}/> : <Crosshair size={20} className={`${config.color} group-hover:scale-110 transition-transform duration-300`}/>}
+                    {defense.defense_key.includes('plasma') ? <Zap size={20} className={`${theme.color} group-hover:scale-110 transition-transform duration-300`}/> : <Crosshair size={20} className={`${theme.color} group-hover:scale-110 transition-transform duration-300`}/>}
                  </div>
                  <div className="space-y-1">
                    <div className="text-[9px] font-mono text-slate-400">
-                     {Math.floor(cost.metal).toLocaleString()}M {cost.crystal > 0 && `/ ${Math.floor(cost.crystal).toLocaleString()}C`}
+                     {Math.floor(defense.base_cost_metal).toLocaleString()}M {defense.base_cost_crystal > 0 && `/ ${Math.floor(defense.base_cost_crystal).toLocaleString()}C`}
                    </div>
-                   <span className="text-[10px] font-mono text-slate-500">{config.time}s / unité</span>
+                   <span className="text-[10px] font-mono text-slate-500">{defense.base_time_seconds}s / unité</span>
                  </div>
               </button>
             );
@@ -159,45 +209,53 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
         </div>
 
         {/* PANNEAU CENTRAL */}
-        <div className={`relative overflow-hidden rounded-3xl border ${selectedConfig.border} bg-black/60 backdrop-blur-md p-8 shadow-2xl card-depth hover:shadow-3xl transition-all duration-500 animate-slide-up glass-card`}>
+        <div className={`relative overflow-hidden rounded-3xl border ${selectedTheme.border} bg-black/60 backdrop-blur-md p-8 shadow-2xl card-depth hover:shadow-3xl transition-all duration-500 animate-slide-up glass-card`}>
            <div className={`absolute -right-10 -bottom-10 opacity-10 ${isBusy ? 'animate-pulse' : 'group-hover:animate-float'}`}>
-             <Shield size={250} className={selectedConfig.color} />
+             <Shield size={250} className={selectedTheme.color} />
            </div>
 
            <div className="relative z-10 space-y-6">
               {/* Image de la défense */}
               <GameImage
                 src={getDefenseImage(selected)}
-                alt={selectedConfig.name}
+                alt={selectedDefense.name}
                 className="w-full h-48 mb-4"
-                fallbackIcon={selected === 'plasma_turret' ? <Zap className={`${selectedConfig.color} w-24 h-24`} /> : <Crosshair className={`${selectedConfig.color} w-24 h-24`} />}
+                fallbackIcon={selectedDefense.defense_key.includes('plasma') ? <Zap className={`${selectedTheme.color} w-24 h-24`} /> : <Crosshair className={`${selectedTheme.color} w-24 h-24`} />}
                 loading="lazy"
               />
 
               <div>
-                  <h2 className="text-3xl font-black uppercase text-white italic">{selectedConfig.name}</h2>
-                  <p className="text-xs text-slate-400">{selectedConfig.desc}</p>
+                  <h2 className="text-3xl font-black uppercase text-white italic">{selectedDefense.name}</h2>
+                  <p className="text-xs text-slate-400">{selectedDefense.description || "Système défensif planétaire"}</p>
               </div>
 
               <div className="flex gap-4">
                  <div className="bg-black/40 px-3 py-2 rounded border border-white/5 text-[10px] text-slate-300 font-bold">
-                    ATK: <span className="text-white">{selectedConfig.atk}</span>
+                    ATK: <span className="text-white">{selectedDefense.attack}</span>
                  </div>
                  <div className="bg-black/40 px-3 py-2 rounded border border-white/5 text-[10px] text-slate-300 font-bold">
-                    DEF: <span className="text-white">{selectedConfig.def}</span>
+                    SHD: <span className="text-white">{selectedDefense.shield}</span>
+                 </div>
+                 <div className="bg-black/40 px-3 py-2 rounded border border-white/5 text-[10px] text-slate-300 font-bold">
+                    HULL: <span className="text-white">{selectedDefense.hull}</span>
                  </div>
               </div>
 
               {/* Prerequisites */}
-              {requirements.length > 0 && (
+              {selectedDefense.requirements.length > 0 && (
                 <div className="space-y-2">
                   <label className="text-[10px] uppercase font-bold text-slate-500">Prérequis</label>
                   <div className="space-y-1">
-                    {requirements.map((req, idx) => (
-                      <div key={idx} className={`text-[11px] font-mono ${req.met ? 'text-green-500' : 'text-red-500'}`}>
-                        {req.met ? '✓' : '✗'} {req.label}
-                      </div>
-                    ))}
+                    {selectedDefense.requirements.map((req, idx) => {
+                      const label = req.requirement_type === 'tech'
+                        ? `${req.tech_name} (Nv.${req.required_level})`
+                        : `${req.building_name} (Nv.${req.required_level})`;
+                      return (
+                        <div key={idx} className={`text-[11px] font-mono ${req.met ? 'text-green-500' : 'text-red-500'}`}>
+                          {req.met ? '✓' : '✗'} {label} [{req.current_level}/{req.required_level}]
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               )}
@@ -233,7 +291,7 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
                       ? 'bg-orange-900/20 text-orange-500 border border-orange-500/50'
                     : !canAfford
                       ? 'bg-red-900/20 text-red-500 border border-red-500/50'
-                      : `bg-black hover:bg-slate-900 text-white border ${selectedConfig.border} ${selectedConfig.glow}`
+                      : `bg-black hover:bg-slate-900 text-white border ${selectedTheme.border} ${selectedTheme.glow}`
                 }`}
               >
                   {isBusy ? (
@@ -266,14 +324,15 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
            </h4>
 
            <div className="space-y-4">
-              <div className="flex justify-between items-center bg-white/5 p-3 rounded-lg border border-white/5 hover:bg-white/10 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg group glass-card">
-                 <span className="text-xs font-bold text-blue-400 uppercase">Lanceurs Missiles</span>
-                 <span className="text-xl text-white font-mono font-black group-hover:scale-110 transition-transform">{planet.missile_launcher_count || 0}</span>
-              </div>
-              <div className="flex justify-between items-center bg-white/5 p-3 rounded-lg border border-white/5 hover:bg-white/10 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg group glass-card">
-                 <span className="text-xs font-bold text-pink-500 uppercase">Tourelles Plasma</span>
-                 <span className="text-xl text-white font-mono font-black group-hover:scale-110 transition-transform">{planet.plasma_turret_count || 0}</span>
-              </div>
+              {defenseTypes.map((defense) => {
+                const theme = getDefenseTheme(defense.defense_key);
+                return (
+                  <div key={defense.id} className="flex justify-between items-center bg-white/5 p-3 rounded-lg border border-white/5 hover:bg-white/10 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg group glass-card">
+                     <span className={`text-xs font-bold ${theme.color} uppercase`}>{defense.name}</span>
+                     <span className="text-xl text-white font-mono font-black group-hover:scale-110 transition-transform">{defense.current_count}</span>
+                  </div>
+                );
+              })}
               
               {isBusy && (
                 <div className="mt-6 p-4 bg-indigo-950/30 rounded-xl border border-indigo-500/30 animate-pulse">

--- a/frontend/src/components/Shipyard.tsx
+++ b/frontend/src/components/Shipyard.tsx
@@ -6,11 +6,38 @@ import {
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
-import { checkPrerequisites } from "@/lib/gameRules";
 import { apiUrl } from '@/config/api';
-import { useUnitCosts } from '@/hooks/useUnitCosts';
 import { GameImage } from '@/components/ui/game-image';
 import { getShipImage } from '@/lib/images';
+
+interface ShipRequirement {
+  requirement_type: string;
+  tech_key?: string;
+  tech_name?: string;
+  building_name?: string;
+  required_level: number;
+  current_level: number;
+  met: boolean;
+}
+
+interface ShipTypeInfo {
+  id: number;
+  ship_key: string;
+  display_name: string;
+  description: string | null;
+  cost_metal: number;
+  cost_crystal: number;
+  cost_deuterium: number;
+  build_time_seconds: number;
+  attack: number;
+  shield: number;
+  hull: number;
+  cargo_capacity: number;
+  base_speed: number;
+  fuel_consumption: number;
+  current_count: number;
+  requirements: ShipRequirement[];
+}
 
 interface ShipyardProps {
   planet: any;
@@ -30,14 +57,33 @@ const getShipTheme = (type: string) => {
 export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
   const [now, setNow] = useState(new Date().getTime());
   const [qty, setQty] = useState<Record<string, number>>({});
-  
-  // ✅ AJOUT : Fetch des coûts depuis le backend
-  const { costs, loading } = useUnitCosts();
+  const [shipTypes, setShipTypes] = useState<ShipTypeInfo[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const interval = setInterval(() => setNow(new Date().getTime()), 1000);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    const fetchShipTypes = async () => {
+      const token = localStorage.getItem('token');
+      try {
+        const response = await fetch(apiUrl(`/planets/${planet.id}/ship-types`), {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setShipTypes(data.ship_types || []);
+        }
+      } catch (e) {
+        console.error("Failed to fetch ship types:", e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchShipTypes();
+  }, [planet.id]);
 
   // --- CALCULS TECHNOLOGIQUES ---
   const bonusAtk = 1 + ((planet.laser_battery_level || 0) * 0.1);
@@ -53,63 +99,51 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
   const queue = planet.constructions || [];
   const isQueueFull = queue.length >= 3;
 
-  // ✅ Configuration des vaisseaux (sans les coûts hardcodés)
-  const fleetConfig = [
-    { 
-      id: 'light_hunter', 
-      name: 'Chasseur Léger', 
-      stats: { atk: 50, shd: 10, hull: 400, fret: 50 }, 
-      icon: Crosshair, 
-      type: 'OFFENSIF', 
-      class: 'Intercepteur', 
-      desc: "Vaisseau d'attaque rapide." 
-    },
-    { 
-      id: 'cruiser', 
-      name: 'Croiseur', 
-      stats: { atk: 400, shd: 50, hull: 2700, fret: 800 }, 
-      icon: Shield, 
-      type: 'OFFENSIF', 
-      class: 'Frégate Lourde', 
-      desc: "Blindé, tueur de chasseurs." 
-    },
-    { 
-      id: 'transporter', 
-      name: 'Transporteur', 
-      stats: { atk: 5, shd: 5, hull: 800, fret: 10000 }, 
-      icon: Truck, 
-      type: 'LOGISTIQUE', 
-      class: 'Cargo Standard', 
-      desc: "Capacité de base 10k (+5%/niveau hangar)." 
-    },
-    { 
-      id: 'colony_ship', 
-      name: 'Vaisseau Colon', 
-      stats: { atk: 50, shd: 100, hull: 3000, fret: 7500 }, 
-      icon: Rocket, 
-      type: 'LOGISTIQUE', 
-      class: 'Module Arche', 
-      desc: "Fonde de nouvelles colonies." 
-    },
-    { 
-      id: 'recycler', 
-      name: 'Recycleur', 
-      stats: { atk: 1, shd: 10, hull: 1600, fret: 20000 }, 
-      icon: Hammer, 
-      type: 'UTILITAIRE', 
-      class: 'Collecteur', 
-      desc: "Récolte les débris spatiaux." 
-    },
-    { 
-      id: 'spy_probe', 
-      name: 'Sonde Espion', 
-      stats: { atk: 0.1, shd: 0.1, hull: 100, fret: 5 }, 
-      icon: Info, 
-      type: 'RENSEIGNEMENT', 
-      class: 'Drone Furtif', 
-      desc: "Scanner longue portée." 
-    },
-  ];
+  // Map ship_key to icon and type
+  const getShipIcon = (ship_key: string) => {
+    const iconMap: Record<string, any> = {
+      light_hunter: Crosshair,
+      heavy_hunter: Scan,
+      cruiser: Shield,
+      battleship: ShieldCheck,
+      bomber: Zap,
+      destroyer: Sword,
+      transporter: Truck,
+      colony_ship: Rocket,
+      recycler: Hammer,
+      spy_probe: Info,
+    };
+    return iconMap[ship_key] || Rocket;
+  };
+
+  const getShipCategory = (ship_key: string): string => {
+    if (['light_hunter', 'heavy_hunter', 'cruiser', 'battleship', 'bomber', 'destroyer'].includes(ship_key)) {
+      return 'OFFENSIF';
+    }
+    if (['transporter', 'colony_ship'].includes(ship_key)) {
+      return 'LOGISTIQUE';
+    }
+    if (['spy_probe'].includes(ship_key)) {
+      return 'RENSEIGNEMENT';
+    }
+    return 'UTILITAIRE';
+  };
+
+  const getShipClass = (ship_key: string): string => {
+    const classMap: Record<string, string> = {
+      light_hunter: 'Intercepteur',
+      heavy_hunter: 'Chasseur Lourd',
+      cruiser: 'Frégate Lourde',
+      battleship: 'Vaisseau de Ligne',
+      bomber: 'Bombardier',
+      destroyer: 'Destroyer',
+      transporter: 'Cargo Standard',
+      colony_ship: 'Module Arche',
+      recycler: 'Collecteur',
+      spy_probe: 'Drone Furtif',
+    };
+    return classMap[ship_key] || 'Vaisseau';
+  };
 
   const buildShip = async (type: string) => {
     const amount = qty[type] || 1;
@@ -131,11 +165,10 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
     } catch(e) { console.error(e); }
   };
 
-  // ✅ Afficher un loader pendant le chargement des coûts
-  if (loading || !costs) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-500"></div>
+        <div className="text-slate-400 animate-pulse">Chargement du chantier spatial...</div>
       </div>
     );
   }
@@ -170,30 +203,25 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
       </Card>
 
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-      {fleetConfig.map((shipConfig) => {
-        // ✅ Récupérer les coûts dynamiques depuis le backend
-        const shipCost = costs[shipConfig.id as keyof typeof costs];
-        if (!shipCost) return null; // Skip si pas de coût disponible
+      {shipTypes.map((ship) => {
+        const shipIcon = getShipIcon(ship.ship_key);
+        const shipCategory = getShipCategory(ship.ship_key);
+        const shipClass = getShipClass(ship.ship_key);
 
-        const ship = {
-          ...shipConfig,
-          cost: {
-            m: Math.floor(shipCost.metal),
-            c: Math.floor(shipCost.crystal)
-          }
-        };
+        // Check if requirements are met
+        const locked = ship.requirements.some(req => !req.met);
 
-        const { locked, requirements } = checkPrerequisites(planet, ship.id);
-        const theme = getShipTheme(ship.type);
-        const canAfford = planet.metal_amount >= ship.cost.m && planet.crystal_amount >= ship.cost.c;
-        const currentAmount = planet[`${ship.id}_count`] || 0;
-        
-        const activeItem = queue.find((q: any) => q.building_type === ship.id);
+        const theme = getShipTheme(shipCategory);
+        const canAfford = planet.metal_amount >= ship.cost_metal && planet.crystal_amount >= ship.cost_crystal;
+
+        const activeItem = queue.find((q: any) => q.building_type === ship.ship_key);
         const timeLeft = activeItem ? Math.max(0, Math.floor((new Date(activeItem.end_time + "Z").getTime() - now) / 1000)) : null;
 
-        const maxMetal = ship.cost.m > 0 ? Math.floor(planet.metal_amount / ship.cost.m) : Infinity;
-        const maxCrystal = ship.cost.c > 0 ? Math.floor(planet.crystal_amount / ship.cost.c) : Infinity;
+        const maxMetal = ship.cost_metal > 0 ? Math.floor(planet.metal_amount / ship.cost_metal) : Infinity;
+        const maxCrystal = ship.cost_crystal > 0 ? Math.floor(planet.crystal_amount / ship.cost_crystal) : Infinity;
         const maxBuildable = Math.min(maxMetal, maxCrystal, remainingSpace);
+
+        const ShipIcon = shipIcon;
 
         return (
           <Card key={ship.id} className={`relative overflow-hidden border-t-4 ${locked ? 'border-slate-800 bg-black/60' : `${theme.border} bg-gradient-to-b ${theme.gradient}`} shadow-2xl group transition-all duration-500 hover:-translate-y-2 hover:shadow-3xl hover-scale card-depth card-depth-hover animate-slide-up`}>
@@ -202,12 +230,19 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
                     <div className="bg-red-950/30 p-3 rounded-full border border-red-900 mb-4 animate-pulse"><Lock size={24} className="text-red-500" /></div>
                     <h3 className="text-red-500 font-black uppercase tracking-widest text-sm mb-4">Schéma Verrouillé</h3>
                     <div className="space-y-2 w-full max-w-[200px]">
-                        {requirements.map((req, i) => (
+                        {ship.requirements.map((req, i) => {
+                          const label = req.requirement_type === 'tech'
+                            ? `${req.tech_name} (Nv.${req.required_level})`
+                            : `${req.building_name} (Nv.${req.required_level})`;
+                          return (
                             <div key={i} className="flex justify-between items-center text-[10px] font-mono border-b border-white/5 pb-1">
-                                <span className={req.met ? "text-slate-400" : "text-red-400 font-bold"}>{req.label}</span>
+                                <span className={req.met ? "text-slate-400" : "text-red-400 font-bold"}>
+                                  {label} [{req.current_level}/{req.required_level}]
+                                </span>
                                 {req.met ? <CheckCircle2 size={10} className="text-green-500"/> : <XCircle size={10} className="text-red-500"/>}
                             </div>
-                        ))}
+                          );
+                        })}
                     </div>
                 </div>
             )}
@@ -215,66 +250,66 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
             <CardContent className="p-5 relative z-10 flex flex-col h-full">
               {/* Image du vaisseau */}
               <GameImage
-                src={getShipImage(ship.id)}
-                alt={ship.name}
+                src={getShipImage(ship.ship_key)}
+                alt={ship.display_name}
                 className="w-full h-40 mb-4"
-                fallbackIcon={<ship.icon className={`${theme.color} w-20 h-20`} />}
+                fallbackIcon={<ShipIcon className={`${theme.color} w-20 h-20`} />}
                 loading="lazy"
               />
 
               <div className="flex justify-between items-start mb-4">
                 <div className="flex gap-4 items-center">
                    <div className={`p-3 rounded-xl border ${theme.border} bg-black/40 shadow-lg group-hover:scale-105 transition-transform`}>
-                     <ship.icon className={theme.color} size={24} />
+                     <ShipIcon className={theme.color} size={24} />
                    </div>
                    <div>
-                      <div className={`text-[9px] font-black uppercase tracking-[0.2em] ${theme.color} mb-1 flex items-center gap-1`}><Zap size={10} /> {ship.type}</div>
-                      <h3 className="text-lg font-black uppercase text-white leading-none">{ship.name}</h3>
-                      <p className="text-[10px] text-slate-500 font-mono mt-0.5 tracking-wider">CLASSE: {ship.class}</p>
+                      <div className={`text-[9px] font-black uppercase tracking-[0.2em] ${theme.color} mb-1 flex items-center gap-1`}><Zap size={10} /> {shipCategory}</div>
+                      <h3 className="text-lg font-black uppercase text-white leading-none">{ship.display_name}</h3>
+                      <p className="text-[10px] text-slate-500 font-mono mt-0.5 tracking-wider">CLASSE: {shipClass}</p>
                    </div>
                 </div>
                 <div className="text-right bg-black/30 px-2 py-1 rounded border border-white/5">
-                    <span className="text-xl font-mono font-black text-white">{currentAmount.toLocaleString()}</span>
+                    <span className="text-xl font-mono font-black text-white">{ship.current_count.toLocaleString()}</span>
                     <p className="text-[8px] text-slate-500 uppercase font-bold tracking-widest">En Stock</p>
                 </div>
               </div>
 
               {/* STATS DE COMBAT RÉELLES */}
               <div className="grid grid-cols-4 gap-1.5 mb-4">
-                 <StatBox icon={Sword} label="ATK" value={Math.floor(ship.stats.atk * bonusAtk)} color="text-red-400" />
-                 <StatBox icon={Shield} label="SHD" value={Math.floor(ship.stats.shd * bonusShd)} color="text-cyan-400" />
-                 <StatBox icon={ShieldCheck} label="HULL" value={Math.floor(ship.stats.hull * bonusHull)} color="text-emerald-400" />
-                 <StatBox icon={Box} label="CAP" value={ship.stats.fret} color="text-amber-400" />
+                 <StatBox icon={Sword} label="ATK" value={Math.floor(ship.attack * bonusAtk)} color="text-red-400" />
+                 <StatBox icon={Shield} label="SHD" value={Math.floor(ship.shield * bonusShd)} color="text-cyan-400" />
+                 <StatBox icon={ShieldCheck} label="HULL" value={Math.floor(ship.hull * bonusHull)} color="text-emerald-400" />
+                 <StatBox icon={Box} label="CAP" value={ship.cargo_capacity} color="text-amber-400" />
               </div>
 
 {/* Coûts dynamiques selon quantité */}
 <div className="space-y-2 mb-4">
-  <div className={`flex justify-between items-center px-2 py-1.5 rounded bg-black/40 border ${planet.metal_amount >= ship.cost.m * (qty[ship.id] || 1) ? 'border-white/5' : 'border-red-900/50'}`}>
+  <div className={`flex justify-between items-center px-2 py-1.5 rounded bg-black/40 border ${planet.metal_amount >= ship.cost_metal * (qty[ship.ship_key] || 1) ? 'border-white/5' : 'border-red-900/50'}`}>
      <span className="text-[9px] uppercase font-bold text-slate-500 flex items-center gap-2">
        <Box size={10} /> Métal
      </span>
      <div className="flex flex-col items-end">
-       <span className={`text-sm font-mono font-black ${planet.metal_amount >= ship.cost.m * (qty[ship.id] || 1) ? 'text-white' : 'text-red-500'}`}>
-         {(ship.cost.m * (qty[ship.id] || 1)).toLocaleString()}
+       <span className={`text-sm font-mono font-black ${planet.metal_amount >= ship.cost_metal * (qty[ship.ship_key] || 1) ? 'text-white' : 'text-red-500'}`}>
+         {(ship.cost_metal * (qty[ship.ship_key] || 1)).toLocaleString()}
        </span>
-       {(qty[ship.id] || 0) > 1 && (
+       {(qty[ship.ship_key] || 0) > 1 && (
          <span className="text-[10px] text-slate-400 font-mono font-bold">
-           {ship.cost.m.toLocaleString()} × {qty[ship.id]}
+           {ship.cost_metal.toLocaleString()} × {qty[ship.ship_key]}
          </span>
        )}
      </div>
   </div>
-  <div className={`flex justify-between items-center px-2 py-1.5 rounded bg-black/40 border ${planet.crystal_amount >= ship.cost.c * (qty[ship.id] || 1) ? 'border-white/5' : 'border-red-900/50'}`}>
+  <div className={`flex justify-between items-center px-2 py-1.5 rounded bg-black/40 border ${planet.crystal_amount >= ship.cost_crystal * (qty[ship.ship_key] || 1) ? 'border-white/5' : 'border-red-900/50'}`}>
      <span className="text-[9px] uppercase font-bold text-slate-500 flex items-center gap-2">
        <Box size={10} /> Cristal
      </span>
      <div className="flex flex-col items-end">
-       <span className={`text-sm font-mono font-black ${planet.crystal_amount >= ship.cost.c * (qty[ship.id] || 1) ? 'text-white' : 'text-red-500'}`}>
-         {(ship.cost.c * (qty[ship.id] || 1)).toLocaleString()}
+       <span className={`text-sm font-mono font-black ${planet.crystal_amount >= ship.cost_crystal * (qty[ship.ship_key] || 1) ? 'text-white' : 'text-red-500'}`}>
+         {(ship.cost_crystal * (qty[ship.ship_key] || 1)).toLocaleString()}
        </span>
-       {(qty[ship.id] || 0) > 1 && (
+       {(qty[ship.ship_key] || 0) > 1 && (
          <span className="text-[10px] text-slate-400 font-mono font-bold">
-           {ship.cost.c.toLocaleString()} × {qty[ship.id]}
+           {ship.cost_crystal.toLocaleString()} × {qty[ship.ship_key]}
          </span>
        )}
      </div>
@@ -286,11 +321,11 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
               <div className="mt-auto">
                 <div className="flex justify-between text-[10px] mb-1 px-1">
                    <span className="text-slate-500 uppercase font-bold">Production</span>
-                   <button onClick={() => !locked && !isQueueFull && !isFull && setQty({...qty, [ship.id]: maxBuildable})} className={`uppercase font-bold tracking-wider hover:text-white transition-colors ${maxBuildable > 0 ? 'text-indigo-400 cursor-pointer' : 'text-slate-600 cursor-not-allowed'}`}>Max: {maxBuildable.toLocaleString()}</button>
+                   <button onClick={() => !locked && !isQueueFull && !isFull && setQty({...qty, [ship.ship_key]: maxBuildable})} className={`uppercase font-bold tracking-wider hover:text-white transition-colors ${maxBuildable > 0 ? 'text-indigo-400 cursor-pointer' : 'text-slate-600 cursor-not-allowed'}`}>Max: {maxBuildable.toLocaleString()}</button>
                 </div>
                 <div className="flex gap-2">
-                    <input type="number" min="1" max={maxBuildable} value={qty[ship.id] || ''} placeholder="0" className="w-20 bg-black/50 border border-white/10 rounded-lg text-center text-white text-sm font-bold focus:outline-none focus:border-indigo-500 transition-colors" onChange={(e) => setQty({...qty, [ship.id]: parseInt(e.target.value)})} disabled={locked || isQueueFull || isFull} />
-                    <Button onClick={() => buildShip(ship.id)} disabled={locked || isQueueFull || !canAfford || (qty[ship.id] || 0) <= 0 || isFull} className={`flex-1 h-10 font-black uppercase text-[10px] tracking-[0.2em] transition-all rounded-lg relative overflow-hidden group/btn ${isQueueFull ? 'bg-slate-800 text-slate-500 border border-slate-700' : isFull ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : !canAfford ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : `bg-black hover:bg-slate-900 text-white border ${theme.border} hover:shadow-[0_0_20px_rgba(255,255,255,0.1)]`}`}>
+                    <input type="number" min="1" max={maxBuildable} value={qty[ship.ship_key] || ''} placeholder="0" className="w-20 bg-black/50 border border-white/10 rounded-lg text-center text-white text-sm font-bold focus:outline-none focus:border-indigo-500 transition-colors" onChange={(e) => setQty({...qty, [ship.ship_key]: parseInt(e.target.value)})} disabled={locked || isQueueFull || isFull} />
+                    <Button onClick={() => buildShip(ship.ship_key)} disabled={locked || isQueueFull || !canAfford || (qty[ship.ship_key] || 0) <= 0 || isFull} className={`flex-1 h-10 font-black uppercase text-[10px] tracking-[0.2em] transition-all rounded-lg relative overflow-hidden group/btn ${isQueueFull ? 'bg-slate-800 text-slate-500 border border-slate-700' : isFull ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : !canAfford ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : `bg-black hover:bg-slate-900 text-white border ${theme.border} hover:shadow-[0_0_20px_rgba(255,255,255,0.1)]`}`}>
                         {activeItem ? (
                              <span className="flex items-center gap-2 relative z-10 text-orange-300">
                                 <Timer size={14} className="animate-spin" /> En cours ({timeLeft}s)


### PR DESCRIPTION
Expansion 2.0 - Complete Frontend Integration for Ships & Defenses:

SHIPYARD COMPONENT:
- Fetches ship types from /planets/:id/ship-types API
- Displays all ships with tech and building requirements from database
- Shows requirement status with current vs required levels
- Added mapping functions for ship icons, categories, and classes
- Dynamic ship stats (attack, shield, hull, cargo) from database
- Removed useUnitCosts hook - costs now from ship_types table
- Red lock overlay for ships with unmet tech requirements
- Requirement display: "Tech Name (Nv.5) [3/5]" with visual indicators

DEFENSES COMPONENT:
- Fetches defense types from /planets/:id/defense-types API
- Displays all defenses with tech and building requirements
- Dynamic defense selection grid with locked state for unmet requirements
- Shows attack, shield, and hull stats from database
- Auto-adapts color themes based on defense type (laser=red, plasma=pink, ion=purple, etc.)
- Right panel shows all defense counts dynamically
- Requirement display with green checkmarks (met) and red X (unmet)

Both components:
- No hardcoded data - all from database migrations
- Maintain existing cyberpunk design aesthetic
- Visual requirement validation before construction
- Full integration with tech tree dependency system

Example: Plasma Turret requires "Plasma Tech (Nv.7)" and shows [5/7] if current level is 5