### PR TITLE
fix(frontend): Add missing techTreeCompat imports to all components

### DIFF
--- a/frontend/src/components/EmpireBar.tsx
+++ b/frontend/src/components/EmpireBar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { apiUrl } from '@/config/api';
 import { useRealtimeResources } from '@/hooks/useRealtimeResources';
 import { ConnectionStatus, getConnectionStatusColor, getConnectionStatusText } from '@/hooks/useWebSocket';
+import { getTechLevel } from '@/utils/techTreeCompat';
 import {
   Zap,
   Stone,

--- a/frontend/src/components/MyPlanets.tsx
+++ b/frontend/src/components/MyPlanets.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { toast } from "sonner";
 import { apiUrl } from '@/config/api';
+import { getTechLevel, getShipCount } from '@/utils/techTreeCompat';
 
 interface Planet {
   id: string;

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -23,6 +23,7 @@ import { apiUrl } from '@/config/api';
 import { toast } from "sonner";
 import { GameImage } from '@/components/ui/game-image';
 import { getResourceImage } from '@/lib/images';
+import { getTechLevel } from '@/utils/techTreeCompat';
 
 interface ResourceSlot {
   id: number;

--- a/frontend/src/components/Shipyard.tsx
+++ b/frontend/src/components/Shipyard.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { apiUrl } from '@/config/api';
 import { GameImage } from '@/components/ui/game-image';
 import { getShipImage } from '@/lib/images';
+import { getTechLevel, getShipCount } from '@/utils/techTreeCompat';
 
 interface ShipRequirement {
   requirement_type: string;

--- a/frontend/src/lib/gameRules.ts
+++ b/frontend/src/lib/gameRules.ts
@@ -1,4 +1,5 @@
 // frontend/src/lib/gameRules.ts
+import { getTechLevel, getShipCount } from '@/utils/techTreeCompat';
 
 export interface Requirement {
     label: string;


### PR DESCRIPTION
- Added getTechLevel import to EmpireBar.tsx
- Added getTechLevel and getShipCount imports to MyPlanets.tsx
- Added getTechLevel import to ResourceDisplay.tsx
- Added getTechLevel and getShipCount imports to Shipyard.tsx
- Added getTechLevel and getShipCount imports to gameRules.ts

Fixes "getTechLevel is not defined" runtime error