### PR TITLE
fix: Correct planet_buildings and planet_defenses entity definitions

### DIFF
--- a/backend/src/entities/planet_building.rs
+++ b/backend/src/entities/planet_building.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 #[sea_orm(table_name = "planet_buildings")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
     pub planet_id: Uuid,
+    #[sea_orm(primary_key)]
     pub building_type_id: i32,
-    pub current_level: i32,
+    pub level: i32,
     pub upgrading_to_level: Option<i32>,
     pub upgrade_end_time: Option<DateTime>,
     pub updated_at: Option<DateTime>,

--- a/backend/src/entities/planet_defense.rs
+++ b/backend/src/entities/planet_defense.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "planet_defenses")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: i32,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub planet_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub defense_type_id: i32,
-    pub defense_count: i32,
-    pub building_count: i32,
+    pub count: i32,
+    pub building_count: Option<i32>,
     pub build_end_time: Option<DateTime>,
     pub updated_at: Option<DateTime>,
 }

--- a/backend/src/tech_tree.rs
+++ b/backend/src/tech_tree.rs
@@ -479,7 +479,7 @@ pub async fn get_planet_building_level(
         .one(db)
         .await?;
 
-    Ok(planet_building.map(|pb| pb.current_level).unwrap_or(0))
+    Ok(planet_building.map(|pb| pb.level).unwrap_or(0))
 }
 
 /// Get all building levels for a planet as a HashMap
@@ -496,7 +496,7 @@ pub async fn get_all_planet_building_levels(
 
     for pb in planet_buildings {
         if let Some(building) = BuildingType::find_by_id(pb.building_type_id).one(db).await? {
-            result.insert(building.building_key, pb.current_level);
+            result.insert(building.building_key, pb.level);
         }
     }
 
@@ -629,7 +629,7 @@ pub async fn get_planet_defense_count(
         .one(db)
         .await?;
 
-    Ok(planet_defense.map(|pd| pd.defense_count).unwrap_or(0))
+    Ok(planet_defense.map(|pd| pd.count).unwrap_or(0))
 }
 
 /// Get all defense counts for a planet as a HashMap
@@ -646,7 +646,7 @@ pub async fn get_all_planet_defense_counts(
 
     for pd in planet_defenses {
         if let Some(defense_type) = DefenseType::find_by_id(pd.defense_type_id).one(db).await? {
-            result.insert(defense_type.defense_key, pd.defense_count);
+            result.insert(defense_type.defense_key, pd.count);
         }
     }
 


### PR DESCRIPTION
Fixed critical schema mismatch issues:

**planet_buildings:**
- Removed non-existent id column
- Changed to composite primary key (planet_id, building_type_id)
- Renamed current_level → level to match DB schema

**planet_defenses:**
- Removed non-existent id column
- Changed to composite primary key (planet_id, defense_type_id)
- Renamed defense_count → count to match DB schema
- Changed building_count from i32 to Option<i32>

**tech_tree.rs:**
- Updated all references from current_level to level
- Updated all references from defense_count to count

These entities were incorrectly defined with auto-increment id columns that don't exist in the database, causing "column does not exist" errors on all queries.