### PR TITLE
feat: Add error logging to ship-types endpoint handler

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4078,7 +4078,10 @@ async fn get_ship_types_handler(
 ) -> impl IntoResponse {
     match tech_tree::get_ship_types_for_planet(&state.db, planet_id).await {
         Ok(ship_types) => Json(json!({ "ship_types": ship_types })).into_response(),
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to fetch ship types"}))).into_response(),
+        Err(e) => {
+            eprintln!("❌ Error fetching ship types for planet {}: {:?}", planet_id, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to fetch ship types"}))).into_response()
+        }
     }
 }
 


### PR DESCRIPTION
- Added error logging with eprintln! to get_ship_types_handler
- Ensures consistent error handling across all tech tree endpoints
- Matches the error handling pattern used in building-types and defense-types handlers