### PR TITLE
fix: Update frontend components to use dynamic API endpoints

### DIFF
--- a/frontend/src/components/ExpeditionZoneV2.tsx
+++ b/frontend/src/components/ExpeditionZoneV2.tsx
@@ -31,25 +31,42 @@ export default function ExpeditionZoneV2({ planet, onAction }: { planet: any, on
   const [availableShips, setAvailableShips] = useState<PlanetShip[]>([]);
   const [combatReport, setCombatReport] = useState<any>(null);
 
-  // Load available ships from planet.ships
+  // Load available ships from ship-types endpoint
   useEffect(() => {
-    if (planet?.ships) {
-      const ships: PlanetShip[] = Object.entries(planet.ships).map(([key, value]: [string, any]) => ({
-        ship_key: key,
-        count: value.count || 0,
-        display_name: value.display_name || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
-      })).filter((ship: PlanetShip) => ship.count > 0);
+    const fetchShipTypes = async () => {
+      const token = localStorage.getItem('token');
+      try {
+        const response = await fetch(`${API_URL}/planets/${planet.id}/ship-types`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        if (response.ok) {
+          const data = await response.json();
+          const ships: PlanetShip[] = (data.ship_types || [])
+            .filter((ship: any) => ship.current_count > 0)
+            .map((ship: any) => ({
+              ship_key: ship.ship_key,
+              count: ship.current_count,
+              display_name: ship.display_name
+            }));
 
-      setAvailableShips(ships);
+          setAvailableShips(ships);
 
-      // Initialize selection to 0 for all ship types
-      const initialSelection: ShipSelection = {};
-      ships.forEach(ship => {
-        initialSelection[ship.ship_key] = 0;
-      });
-      setShipSelection(initialSelection);
+          // Initialize selection to 0 for all ship types
+          const initialSelection: ShipSelection = {};
+          ships.forEach(ship => {
+            initialSelection[ship.ship_key] = 0;
+          });
+          setShipSelection(initialSelection);
+        }
+      } catch (e) {
+        console.error("Failed to fetch ship types:", e);
+      }
+    };
+
+    if (planet?.id) {
+      fetchShipTypes();
     }
-  }, [planet?.ships]);
+  }, [planet?.id]);
 
   // Reset on planet change
   useEffect(() => {

--- a/frontend/src/components/Facilities.tsx
+++ b/frontend/src/components/Facilities.tsx
@@ -249,6 +249,19 @@ export default function Facilities({ planet, onUpgrade }: FacilitiesProps) {
                     </div>
                 )}
 
+                {/* TEMPS DE CONSTRUCTION */}
+                {!locked && (
+                    <div className="mb-4 p-2 bg-black/30 rounded border border-white/5 flex items-center justify-between glass-card">
+                        <div className="flex items-center gap-2 text-[10px] font-bold uppercase text-slate-500">
+                            <Timer size={12} className={`${theme.color}`} />
+                            <span>Temps Construction</span>
+                        </div>
+                        <div className="text-xs font-mono text-slate-300">
+                            {Math.floor(building.base_time_seconds / 60)}m {building.base_time_seconds % 60}s
+                        </div>
+                    </div>
+                )}
+
                 {/* PRÉREQUIS SI VERROUILLÉ */}
                 {locked && building.requirements.length > 0 && (
                   <div className="mb-4 p-3 bg-red-950/20 rounded border border-red-500/20 space-y-1">

--- a/frontend/src/components/Shipyard.tsx
+++ b/frontend/src/components/Shipyard.tsx
@@ -9,7 +9,7 @@ import { toast } from "sonner";
 import { apiUrl } from '@/config/api';
 import { GameImage } from '@/components/ui/game-image';
 import { getShipImage } from '@/lib/images';
-import { getTechLevel, getShipCount } from '@/utils/techTreeCompat';
+import { getTechLevel } from '@/utils/techTreeCompat';
 
 interface ShipRequirement {
   requirement_type: string;
@@ -91,7 +91,8 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
   const bonusShd = 1 + ((getTechLevel(planet, 'energy_tech')) * 0.1);
   const bonusHull = 1 + ((getTechLevel(planet, 'armour_tech')) * 0.1);
 
-  const currentFleet = (getShipCount(planet, 'light_hunter')||0) + (getShipCount(planet, 'cruiser')||0) + (getShipCount(planet, 'transporter')||0) + (getShipCount(planet, 'colony_ship')||0) + (getShipCount(planet, 'recycler')||0) + (getShipCount(planet, 'spy_probe')||0);
+  // Calculate current fleet from dynamic ship types data
+  const currentFleet = shipTypes.reduce((total, ship) => total + ship.current_count, 0);
   const maxFleet = 500 + ((planet.hangar_level || 0) * 500);
   const capacityPercent = Math.min(100, (currentFleet / maxFleet) * 100);
   const isFull = currentFleet >= maxFleet;
@@ -151,7 +152,7 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
     if (amount > remainingSpace) { toast.error("Capacité insuffisante !"); return; }
     const token = localStorage.getItem('token');
     try {
-        const res = await fetch(apiUrl(`/planets/${planet.id}/build-fleet/${type}/${amount}`), {
+        const res = await fetch(apiUrl(`/planets/${planet.id}/build-ships/${type}/${amount}`), {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` }
         });


### PR DESCRIPTION
Facilities.tsx:
- Added build time display using base_time_seconds from API
- Already using dynamic building-types endpoint correctly

Shipyard.tsx:
- Fixed build endpoint from /build-fleet/ to /build-ships/
- Changed fleet capacity calculation to use shipTypes data instead of getShipCount
- Removed unused getShipCount import
- Now properly displays ship counts from dynamic ship-types API

ExpeditionZoneV2.tsx:
- Changed to fetch ship types from /ship-types endpoint
- Removed dependency on planet.ships object which backend doesn't populate
- Now uses same pattern as Shipyard component for consistency

These changes ensure all components use the new relational tech tree system instead of the old column-based system.