### PR TITLE
refactor: Use getBuildingLevel() for consistent building data access

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1372,11 +1372,13 @@ async fn get_planet_handler(
         let mut enriched_ship_builds = Vec::new();
         for build in active_ship_builds {
             if let Some(ship_type) = ShipType::find_by_id(build.ship_type_id).one(&state.db).await.unwrap_or(None) {
+                // Format build_end_time as string for consistent parsing
+                let end_time_str = build.build_end_time.map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string());
                 enriched_ship_builds.push(json!({
                     "ship_key": ship_type.ship_key,
                     "name": ship_type.display_name,
                     "building_count": build.building_count,
-                    "build_end_time": build.build_end_time,
+                    "build_end_time": end_time_str,
                 }));
             }
         }
@@ -1394,11 +1396,13 @@ async fn get_planet_handler(
         let mut enriched_defense_builds = Vec::new();
         for build in active_defense_builds {
             if let Some(defense_type) = DefenseType::find_by_id(build.defense_type_id).one(&state.db).await.unwrap_or(None) {
+                // Format build_end_time as string for consistent parsing
+                let end_time_str = build.build_end_time.map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string());
                 enriched_defense_builds.push(json!({
                     "defense_key": defense_type.defense_key,
                     "name": defense_type.name,
                     "building_count": build.building_count,
-                    "build_end_time": build.build_end_time,
+                    "build_end_time": end_time_str,
                 }));
             }
         }

--- a/frontend/src/components/PlanetOverview.tsx
+++ b/frontend/src/components/PlanetOverview.tsx
@@ -10,7 +10,7 @@ import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { apiUrl } from '@/config/api';
 import { useRealtimeResources } from '@/hooks/useRealtimeResources';
-import { getTechLevel, getShipCount, calculateFleetAttack, calculateFleetHull, getTotalFleetCount } from '@/utils/techTreeCompat';
+import { getTechLevel, getBuildingLevel, getShipCount, calculateFleetAttack, calculateFleetHull, getTotalFleetCount } from '@/utils/techTreeCompat';
 // --- Dictionnaire de noms ---
 const getLabel = (id: string | null) => {
     if (!id) return "Inconnu";
@@ -928,11 +928,11 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
 
             <CardContent className="space-y-2 relative z-10">
                 {[
-                    { label: "Mine de Métal", level: planet.metal_mine_level, icon: Stone, color: "text-orange-400", border: "border-orange-500/30", bg: "bg-orange-500/10" },
-                    { label: "Mine de Cristal", level: planet.crystal_mine_level, icon: Gem, color: "text-cyan-400", border: "border-cyan-500/30", bg: "bg-cyan-500/10" },
-                    { label: "Synth. Deutérium", level: planet.deuterium_mine_level, icon: Droplets, color: "text-emerald-400", border: "border-emerald-500/30", bg: "bg-emerald-500/10" },
-                    { label: "Centrale Solaire", level: planet.solar_plant_level, icon: Zap, color: "text-yellow-400", border: "border-yellow-500/30", bg: "bg-yellow-500/10" },
-                    { label: "Hangar", level: planet.hangar_level || 0, icon: Warehouse, color: "text-blue-400", border: "border-blue-500/30", bg: "bg-blue-500/10" }, 
+                    { label: "Mine de Métal", level: getBuildingLevel(planet, 'metal_mine'), icon: Stone, color: "text-orange-400", border: "border-orange-500/30", bg: "bg-orange-500/10" },
+                    { label: "Mine de Cristal", level: getBuildingLevel(planet, 'crystal_mine'), icon: Gem, color: "text-cyan-400", border: "border-cyan-500/30", bg: "bg-cyan-500/10" },
+                    { label: "Synth. Deutérium", level: getBuildingLevel(planet, 'deuterium_mine'), icon: Droplets, color: "text-emerald-400", border: "border-emerald-500/30", bg: "bg-emerald-500/10" },
+                    { label: "Centrale Solaire", level: getBuildingLevel(planet, 'solar_plant'), icon: Zap, color: "text-yellow-400", border: "border-yellow-500/30", bg: "bg-yellow-500/10" },
+                    { label: "Hangar", level: getBuildingLevel(planet, 'hangar'), icon: Warehouse, color: "text-blue-400", border: "border-blue-500/30", bg: "bg-blue-500/10" },
                 ].map((mine) => (
                     <div key={mine.label} className={`bg-black/40 border ${mine.border} p-2.5 rounded-lg flex items-center justify-between group hover:${mine.bg} transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg`}>
                         <div className="flex items-center gap-2.5 overflow-hidden">
@@ -955,7 +955,7 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
                     <div className="relative h-2 w-full bg-slate-900 rounded-full overflow-hidden border border-white/10">
                         <div
                             className="h-full bg-gradient-to-r from-indigo-600 via-purple-500 to-cyan-400 transition-all duration-500"
-                            style={{ width: `${Math.min(100, ((planet.metal_mine_level + planet.crystal_mine_level + planet.deuterium_mine_level + planet.solar_plant_level) / 80) * 100)}%` }}
+                            style={{ width: `${Math.min(100, ((getBuildingLevel(planet, 'metal_mine') + getBuildingLevel(planet, 'crystal_mine') + getBuildingLevel(planet, 'deuterium_mine') + getBuildingLevel(planet, 'solar_plant')) / 80) * 100)}%` }}
                         >
                             <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-shimmer"></div>
                         </div>

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -23,7 +23,7 @@ import { apiUrl } from '@/config/api';
 import { toast } from "sonner";
 import { GameImage } from '@/components/ui/game-image';
 import { getResourceImage } from '@/lib/images';
-import { getTechLevel } from '@/utils/techTreeCompat';
+import { getTechLevel, getBuildingLevel } from '@/utils/techTreeCompat';
 
 interface ResourceSlot {
   id: number;
@@ -280,10 +280,10 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
   };
 
   const buildings = [
-    { id: 'metal', name: 'Mine de Métal', lv: planet.metal_mine_level ?? 0, base: config.production_metal_base || 30, growth: config.production_metal_growth || 1.1 },
-    { id: 'crystal', name: 'Mine de Cristal', lv: planet.crystal_mine_level ?? 0, base: config.production_crystal_base || 20, growth: config.production_crystal_growth || 1.1 },
-    { id: 'deuterium', name: 'Synthé de Deutérium', lv: planet.deuterium_mine_level ?? 0, base: config.production_deuterium_base || 10, growth: config.production_deuterium_growth || 1.05 },
-    { id: 'solar_plant', name: 'Centrale Solaire', lv: planet.solar_plant_level ?? 0, base: 0, growth: 1.1 },
+    { id: 'metal_mine', name: 'Mine de Métal', lv: getBuildingLevel(planet, 'metal_mine'), base: config.production_metal_base || 30, growth: config.production_metal_growth || 1.1 },
+    { id: 'crystal_mine', name: 'Mine de Cristal', lv: getBuildingLevel(planet, 'crystal_mine'), base: config.production_crystal_base || 20, growth: config.production_crystal_growth || 1.1 },
+    { id: 'deuterium_mine', name: 'Synthé de Deutérium', lv: getBuildingLevel(planet, 'deuterium_mine'), base: config.production_deuterium_base || 10, growth: config.production_deuterium_growth || 1.05 },
+    { id: 'solar_plant', name: 'Centrale Solaire', lv: getBuildingLevel(planet, 'solar_plant'), base: 0, growth: 1.1 },
   ];
 
   const metalNow = planet.metal_amount ?? 0;

--- a/frontend/src/utils/techTreeCompat.ts
+++ b/frontend/src/utils/techTreeCompat.ts
@@ -25,6 +25,7 @@ export interface Planet {
 
   // New system objects
   technologies?: { [techKey: string]: number };
+  buildings?: { [buildingKey: string]: number };
   ships?: {
     [shipKey: string]: {
       count: number;
@@ -62,6 +63,39 @@ export function getTechLevel(planet: Planet | null | undefined, techKey: string)
   };
 
   const oldColumn = oldColumnMap[techKey];
+  if (oldColumn && planet[oldColumn] !== undefined) {
+    return planet[oldColumn] as number;
+  }
+
+  return 0;
+}
+
+/**
+ * Get building level with fallback to old system
+ */
+export function getBuildingLevel(planet: Planet | null | undefined, buildingKey: string): number {
+  if (!planet) return 0;
+
+  // NEW SYSTEM: Check buildings object first (priority)
+  if (planet.buildings && planet.buildings[buildingKey] !== undefined) {
+    return planet.buildings[buildingKey];
+  }
+
+  // OLD SYSTEM: Fallback to old column names
+  const oldColumnMap: { [key: string]: string } = {
+    'metal_mine': 'metal_mine_level',
+    'crystal_mine': 'crystal_mine_level',
+    'deuterium_mine': 'deuterium_mine_level',
+    'solar_plant': 'solar_plant_level',
+    'fusion_plant': 'fusion_plant_level',
+    'shipyard': 'shipyard_level',
+    'research_lab': 'research_lab_level',
+    'hangar': 'hangar_level',
+    'resource_storage': 'resource_storage_level',
+    // Add more mappings as needed
+  };
+
+  const oldColumn = oldColumnMap[buildingKey];
   if (oldColumn && planet[oldColumn] !== undefined) {
     return planet[oldColumn] as number;
   }


### PR DESCRIPTION
Updated frontend to use the new getBuildingLevel() helper function for accessing building levels, providing compatibility between the old column-based system and new relational planet_buildings table.

Changes:
- Added getBuildingLevel() function to techTreeCompat.ts with fallback to old column names (metal_mine_level, crystal_mine_level, etc.)
- Updated ResourceDisplay.tsx to use getBuildingLevel() for mines and solar plant levels
- Updated PlanetOverview.tsx Infrastructures card to use getBuildingLevel()
- Updated industrialization progress bar calculation
- Format build_end_time as string in backend for ships/defenses

This ensures consistent data access across the app and prepares for eventual migration away from legacy planet columns.

Part of: Updating to use new relational system (planet_buildings table)