### PR TITLE
fix: Multiple UI and system improvements

### DIFF
--- a/backend/src/cancel_handlers.rs
+++ b/backend/src/cancel_handlers.rs
@@ -1,0 +1,220 @@
+/// Cancel handlers for ship and defense builds
+///
+/// These handlers allow users to cancel ongoing ship/defense constructions
+/// and receive a partial refund based on remaining build time.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::entities::{prelude::*, planet, planet_defense, planet_ship, defense_type, ship_type};
+use crate::AppState;
+
+/// Cancel an ongoing ship build
+///
+/// DELETE /planets/:id/cancel-ship-build/:ship_key
+///
+/// Cancels the current ship build for the given ship key and refunds resources
+/// based on remaining build time (up to 95% refund).
+#[axum::debug_handler]
+pub async fn cancel_ship_build_handler(
+    Path((planet_id, ship_key)): Path<(Uuid, String)>,
+    State(state): State<AppState>,
+) -> Response {
+    use entities::ship_type;
+
+    // Get planet
+    let planet = match Planet::find_by_id(planet_id).one(&state.db).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "Planet not found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Get ship type
+    let ship = match ShipType::find()
+        .filter(ship_type::Column::ShipKey.eq(&ship_key))
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "Ship type not found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Find the active build
+    let build = match PlanetShip::find()
+        .filter(planet_ship::Column::PlanetId.eq(planet_id))
+        .filter(planet_ship::Column::ShipTypeId.eq(ship.id))
+        .filter(planet_ship::Column::BuildingCount.is_not_null())
+        .filter(planet_ship::Column::BuildEndTime.is_not_null())
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(b)) => b,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "No active build found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Calculate refund
+    let building_count = build.building_count.unwrap_or(0);
+    if building_count <= 0 {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "No units being built"}))).into_response();
+    }
+
+    let now = Utc::now().naive_utc();
+    let end_time = match build.build_end_time {
+        Some(t) => t,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "No build in progress"}))).into_response(),
+    };
+
+    // Calculate total cost
+    let total_cost_metal = ship.cost_metal * building_count;
+    let total_cost_crystal = ship.cost_crystal * building_count;
+    let total_cost_deuterium = ship.cost_deuterium * building_count;
+
+    // Calculate refund based on remaining time (up to 95%)
+    let config = state.config.read().unwrap().clone();
+    let build_time_per_ship = ship.build_time_seconds as f64 / ((config.speed_factor / 100.0) * config.construction_speed);
+    let total_duration = (build_time_per_ship * building_count as f64) as i64;
+    let remaining_seconds = (end_time - now).num_seconds().max(0);
+    let refund_ratio = (remaining_seconds as f64 / total_duration as f64).clamp(0.0, 0.95);
+
+    let refund_metal = (total_cost_metal as f64 * refund_ratio) as i32;
+    let refund_crystal = (total_cost_crystal as f64 * refund_ratio) as i32;
+    let refund_deuterium = (total_cost_deuterium as f64 * refund_ratio) as i32;
+
+    // Refund resources
+    let mut active_planet: planet::ActiveModel = planet.into();
+    active_planet.metal_amount = Set(active_planet.metal_amount.unwrap() + refund_metal as f64);
+    active_planet.crystal_amount = Set(active_planet.crystal_amount.unwrap() + refund_crystal as f64);
+    active_planet.deuterium_amount = Set(active_planet.deuterium_amount.unwrap() + refund_deuterium as f64);
+
+    if let Err(_) = active_planet.update(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to refund resources"}))).into_response();
+    }
+
+    // Cancel the build
+    let mut active_build: planet_ship::ActiveModel = build.into();
+    active_build.building_count = Set(None);
+    active_build.build_end_time = Set(None);
+
+    if let Err(_) = active_build.update(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to cancel build"}))).into_response();
+    }
+
+    Json(json!({
+        "success": true,
+        "refund_metal": refund_metal,
+        "refund_crystal": refund_crystal,
+        "refund_deuterium": refund_deuterium,
+        "refund_ratio": refund_ratio
+    })).into_response()
+}
+
+/// Cancel an ongoing defense build
+///
+/// DELETE /planets/:id/cancel-defense-build/:defense_key
+///
+/// Cancels the current defense build for the given defense key and refunds resources
+/// based on remaining build time (up to 95% refund).
+#[axum::debug_handler]
+pub async fn cancel_defense_build_handler(
+    Path((planet_id, defense_key)): Path<(Uuid, String)>,
+    State(state): State<AppState>,
+) -> Response {
+    use entities::defense_type;
+
+    // Get planet
+    let planet = match Planet::find_by_id(planet_id).one(&state.db).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "Planet not found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Get defense type
+    let defense = match DefenseType::find()
+        .filter(defense_type::Column::DefenseKey.eq(&defense_key))
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(d)) => d,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "Defense type not found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Find the active build
+    let build = match PlanetDefense::find()
+        .filter(planet_defense::Column::PlanetId.eq(planet_id))
+        .filter(planet_defense::Column::DefenseTypeId.eq(defense.id))
+        .filter(planet_defense::Column::BuildingCount.is_not_null())
+        .filter(planet_defense::Column::BuildEndTime.is_not_null())
+        .one(&state.db)
+        .await
+    {
+        Ok(Some(b)) => b,
+        Ok(None) => return (StatusCode::NOT_FOUND, Json(json!({"error": "No active build found"}))).into_response(),
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Database error"}))).into_response(),
+    };
+
+    // Calculate refund
+    let building_count = build.building_count.unwrap_or(0);
+    if building_count <= 0 {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "No units being built"}))).into_response();
+    }
+
+    let now = Utc::now().naive_utc();
+    let end_time = match build.build_end_time {
+        Some(t) => t,
+        None => return (StatusCode::BAD_REQUEST, Json(json!({"error": "No build in progress"}))).into_response(),
+    };
+
+    // Calculate total cost
+    let total_cost_metal = defense.base_cost_metal * building_count;
+    let total_cost_crystal = defense.base_cost_crystal * building_count;
+    let total_cost_deuterium = defense.base_cost_deuterium * building_count;
+
+    // Calculate refund based on remaining time (up to 95%)
+    let config = state.config.read().unwrap().clone();
+    let build_time_per_defense = defense.build_time_seconds as f64 / ((config.speed_factor / 100.0) * config.construction_speed);
+    let total_duration = (build_time_per_defense * building_count as f64) as i64;
+    let remaining_seconds = (end_time - now).num_seconds().max(0);
+    let refund_ratio = (remaining_seconds as f64 / total_duration as f64).clamp(0.0, 0.95);
+
+    let refund_metal = (total_cost_metal as f64 * refund_ratio) as i32;
+    let refund_crystal = (total_cost_crystal as f64 * refund_ratio) as i32;
+    let refund_deuterium = (total_cost_deuterium as f64 * refund_ratio) as i32;
+
+    // Refund resources
+    let mut active_planet: planet::ActiveModel = planet.into();
+    active_planet.metal_amount = Set(active_planet.metal_amount.unwrap() + refund_metal as f64);
+    active_planet.crystal_amount = Set(active_planet.crystal_amount.unwrap() + refund_crystal as f64);
+    active_planet.deuterium_amount = Set(active_planet.deuterium_amount.unwrap() + refund_deuterium as f64);
+
+    if let Err(_) = active_planet.update(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to refund resources"}))).into_response();
+    }
+
+    // Cancel the build
+    let mut active_build: planet_defense::ActiveModel = build.into();
+    active_build.building_count = Set(None);
+    active_build.build_end_time = Set(None);
+
+    if let Err(_) = active_build.update(&state.db).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": "Failed to cancel build"}))).into_response();
+    }
+
+    Json(json!({
+        "success": true,
+        "refund_metal": refund_metal,
+        "refund_crystal": refund_crystal,
+        "refund_deuterium": refund_deuterium,
+        "refund_ratio": refund_ratio
+    })).into_response()
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -41,6 +41,10 @@ use backend::{
     auth, game_logic, combat, entities, config, admin,
     messaging, market, websocket, alliance, missions, officers, sabotage, tech_tree, tick_system, AppState
 };
+
+// Cancel handlers for ship/defense builds
+mod cancel_handlers;
+use cancel_handlers::{cancel_ship_build_handler, cancel_defense_build_handler};
 use config::Config;
 use websocket::WsState;
 
@@ -239,6 +243,8 @@ async fn main() {
         .route("/planets/:id/research/:tech_key", post(start_research_handler))
         .route("/planets/:id/build-ships/:ship_key/:quantity", post(build_ships_handler))
         .route("/planets/:id/build-defenses/:defense_key/:quantity", post(build_defenses_handler))
+        .route("/planets/:id/cancel-ship-build/:ship_key", delete(cancel_ship_build_handler))
+        .route("/planets/:id/cancel-defense-build/:defense_key", delete(cancel_defense_build_handler))
         .route("/tech/:tech_key", get(get_tech_details_handler))
         .route("/ship/:ship_key", get(get_ship_details_handler))
         // Actions
@@ -1432,6 +1438,11 @@ async fn get_planet_handler(
         }));
 
         // ========== EXPANSION 2.0: Add relational tech tree and ship data ==========
+        // Include building levels from relational tables
+        if let Ok(building_levels) = tech_tree::get_all_planet_building_levels(&state.db, updated_model.id).await {
+            obj.insert("buildings".into(), json!(building_levels));
+        }
+
         // Include tech levels and ship counts from relational tables
         if let Ok(tech_levels) = tech_tree::get_all_planet_tech_levels(&state.db, updated_model.id).await {
             obj.insert("technologies".into(), json!(tech_levels));

--- a/frontend/src/components/PlanetOverview.tsx
+++ b/frontend/src/components/PlanetOverview.tsx
@@ -125,14 +125,63 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${token}` }
       });
-      
+
       if (res.ok) {
         const data = await res.json();
         const total = data.refund_metal + data.refund_crystal + data.refund_deuterium;
-        
-        toast.success("Opération annulée", { 
-          description: `Remboursement de ${Math.floor(total).toLocaleString()} ressources (${Math.round(data.ratio * 100)}%).` 
+
+        toast.success("Opération annulée", {
+          description: `Remboursement de ${Math.floor(total).toLocaleString()} ressources (${Math.round(data.ratio * 100)}%).`
         });
+        onUpdate();
+      } else {
+        toast.error("Erreur lors de l'annulation");
+      }
+    } catch (e) {
+      toast.error("Serveur injoignable");
+    }
+  };
+
+  const cancelShipBuild = async (shipKey: string) => {
+    const token = localStorage.getItem('token');
+    try {
+      const res = await fetch(apiUrl(`/planets/${planet.id}/cancel-ship-build/${shipKey}`), {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        const total = data.refund_metal + data.refund_crystal + data.refund_deuterium;
+
+        toast.success("Construction annulée", {
+          description: `Remboursement de ${Math.floor(total).toLocaleString()} ressources (${Math.round(data.refund_ratio * 100)}%).`
+        });
+        onUpdate();
+      } else {
+        toast.error("Erreur lors de l'annulation");
+      }
+    } catch (e) {
+      toast.error("Serveur injoignable");
+    }
+  };
+
+  const cancelDefenseBuild = async (defenseKey: string) => {
+    const token = localStorage.getItem('token');
+    try {
+      const res = await fetch(apiUrl(`/planets/${planet.id}/cancel-defense-build/${defenseKey}`), {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        const total = data.refund_metal + data.refund_crystal + data.refund_deuterium;
+
+        toast.success("Construction annulée", {
+          description: `Remboursement de ${Math.floor(total).toLocaleString()} ressources (${Math.round(data.refund_ratio * 100)}%).`
+        });
+        onUpdate();
       } else {
         toast.error("Erreur lors de l'annulation");
       }
@@ -503,23 +552,29 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
                                                     <Clock size={12} className={index === 0 ? "animate-spin-slow drop-shadow-[0_0_6px_rgba(6,182,212,0.8)]" : ""} />
                                                     <span className="font-black text-sm">{tl}s</span>
                                                 </div>
-                                                {/* Only show cancel button for building queue items (not ships/defenses) */}
-                                                {!item.is_ship && !item.is_defense && (
-                                                    <div className="relative group/cancel">
-                                                        <button
-                                                            onClick={() => cancelOperation(item.id)}
-                                                            className="text-slate-600 hover:text-red-500 transition-all p-1.5 rounded-lg hover:bg-red-500/10 hover:shadow-[0_0_15px_rgba(239,68,68,0.3)] group-hover/cancel:scale-110"
-                                                        >
-                                                            <XCircle size={18} className="drop-shadow-[0_0_4px_currentColor]" />
-                                                        </button>
-                                                        <div className="absolute bottom-full right-0 mb-2 hidden group-hover/cancel:block z-50">
-                                                            <div className="bg-slate-950 border-2 border-red-500/50 text-white text-[10px] p-3 rounded-lg shadow-[0_0_30px_rgba(239,68,68,0.4)] whitespace-nowrap backdrop-blur-md">
-                                                                <span className="text-red-400 font-black uppercase tracking-wider border-b border-red-500/30 pb-1.5 mb-2 block drop-shadow-[0_0_6px_rgba(239,68,68,0.6)]">⚠️ Annulation</span>
-                                                                <span className="text-slate-300 font-semibold">Remboursement: <span className="text-emerald-400 font-black">{refundPercent}%</span></span>
-                                                            </div>
+                                                {/* Cancel button for all queue items */}
+                                                <div className="relative group/cancel">
+                                                    <button
+                                                        onClick={() => {
+                                                            if (item.is_ship) {
+                                                                cancelShipBuild(item.building_type);
+                                                            } else if (item.is_defense) {
+                                                                cancelDefenseBuild(item.building_type);
+                                                            } else {
+                                                                cancelOperation(item.id);
+                                                            }
+                                                        }}
+                                                        className="text-slate-600 hover:text-red-500 transition-all p-1.5 rounded-lg hover:bg-red-500/10 hover:shadow-[0_0_15px_rgba(239,68,68,0.3)] group-hover/cancel:scale-110"
+                                                    >
+                                                        <XCircle size={18} className="drop-shadow-[0_0_4px_currentColor]" />
+                                                    </button>
+                                                    <div className="absolute bottom-full right-0 mb-2 hidden group-hover/cancel:block z-50">
+                                                        <div className="bg-slate-950 border-2 border-red-500/50 text-white text-[10px] p-3 rounded-lg shadow-[0_0_30px_rgba(239,68,68,0.4)] whitespace-nowrap backdrop-blur-md">
+                                                            <span className="text-red-400 font-black uppercase tracking-wider border-b border-red-500/30 pb-1.5 mb-2 block drop-shadow-[0_0_6px_rgba(239,68,68,0.6)]">⚠️ Annulation</span>
+                                                            <span className="text-slate-300 font-semibold">Remboursement: <span className="text-emerald-400 font-black">{refundPercent}%</span></span>
                                                         </div>
                                                     </div>
-                                                )}
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/frontend/src/components/TechTreeVisual.tsx
+++ b/frontend/src/components/TechTreeVisual.tsx
@@ -95,7 +95,7 @@ const TechNode = ({ data }: { data: any }) => {
 
   return (
     <Card className={`
-      relative overflow-hidden w-[280px] transition-all duration-300
+      relative overflow-hidden w-[280px] min-h-[320px] transition-all duration-300
       ${isLocked
         ? 'bg-red-950/20 border-red-900/50 opacity-70'
         : `bg-slate-950 border ${config.border}`
@@ -339,7 +339,7 @@ export default function TechTreeVisual({ planet, onUpdate }: TechTreeVisualProps
     const indexAtDepth = techsAtDepth.findIndex(t => t.tech_key === tech_key);
 
     // Layout vertical : profondeur = Y, index à cette profondeur = X
-    const spacingY = 280; // Espacement vertical entre niveaux
+    const spacingY = 450; // Espacement vertical entre niveaux (augmenté pour éviter les chevauchements)
     const spacingX = 350; // Espacement horizontal entre techs du même niveau
     const startY = 100;
 


### PR DESCRIPTION
- TechTree: Increase vertical spacing (280px → 450px) and add min-height to prevent card overlapping
- Planet API: Add buildings object to response for consistent level display across frontend
- Cancel functionality: Add endpoints and UI for canceling ship/defense builds with partial refund
- PlanetOverview: Restore cancel buttons for all queue items (buildings, ships, defenses)

Fixes:
- TechTree cards overlapping between 2nd and 3rd ranks
- Mine levels showing incorrect values (using old columns instead of new system)
- Missing cancel buttons in construction queue
- Users unable to cancel incorrectly-timed ship/defense builds from before the fix