### PR TITLE
fix: Use scope block instead of drop() for config lock release

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1877,10 +1877,11 @@ async fn attack_handler(
         (att_planet.galaxy, att_planet.system, att_planet.position),
         (target_planet.galaxy, target_planet.system, target_planet.position)
     );
-    let config = state.config.read().unwrap();
-    let flight_speed = config.get_config("flight_speed_multiplier", 5.0);
-    let travel_time = game_logic::calculate_flight_time(dist, flight_speed);
-    drop(config); // Release lock
+    let travel_time = {
+        let config = state.config.read().unwrap();
+        let flight_speed = config.get_config("flight_speed_multiplier", 5.0);
+        game_logic::calculate_flight_time(dist, flight_speed)
+    };
     let arrival = Utc::now().naive_utc() + Duration::seconds(travel_time);
 
     // Deduct ships from attacker using relational tables
@@ -2035,10 +2036,11 @@ async fn attack_v2_handler(
         (att_planet.galaxy, att_planet.system, att_planet.position),
         (target_planet.galaxy, target_planet.system, target_planet.position)
     );
-    let config = state.config.read().unwrap();
-    let flight_speed = config.get_config("flight_speed_multiplier", 5.0);
-    let travel_time = game_logic::calculate_flight_time(dist, flight_speed);
-    drop(config); // Release lock
+    let travel_time = {
+        let config = state.config.read().unwrap();
+        let flight_speed = config.get_config("flight_speed_multiplier", 5.0);
+        game_logic::calculate_flight_time(dist, flight_speed)
+    };
     let arrival = Utc::now().naive_utc() + Duration::seconds(travel_time);
 
     // Serialize fleet to JSON


### PR DESCRIPTION
Fix compilation errors in attack_handler and attack_v2_handler by using a scope block {} instead of drop() to release the config read lock.

This resolves the Handler trait implementation issues.