### PR TITLE
fix: Correct column names in flight_speed_multiplier migration

### DIFF
--- a/backend/migration/src/m20260121_000001_add_flight_speed_config.rs
+++ b/backend/migration/src/m20260121_000001_add_flight_speed_config.rs
@@ -8,11 +8,11 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         // Add flight_speed_multiplier to server_config
         let insert = Query::insert()
-            .into_table(Alias::new("server_config"))
-            .columns([Alias::new("key"), Alias::new("value")])
+            .into_table(ServerConfig::Table)
+            .columns([ServerConfig::ConfigKey, ServerConfig::ConfigValue])
             .values_panic([
                 "flight_speed_multiplier".into(),
-                5.0.into(), // Default: 5x speed (same as original speed_factor effect)
+                "5.0".into(), // Default: 5x speed (same as original speed_factor effect)
             ])
             .to_owned();
 
@@ -24,12 +24,19 @@ impl MigrationTrait for Migration {
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         // Remove flight_speed_multiplier from server_config
         let delete = Query::delete()
-            .from_table(Alias::new("server_config"))
-            .and_where(Expr::col(Alias::new("key")).eq("flight_speed_multiplier"))
+            .from_table(ServerConfig::Table)
+            .and_where(Expr::col(ServerConfig::ConfigKey).eq("flight_speed_multiplier"))
             .to_owned();
 
         manager.exec_stmt(delete).await?;
 
         Ok(())
     }
+}
+
+#[derive(DeriveIden)]
+enum ServerConfig {
+    Table,
+    ConfigKey,
+    ConfigValue,
 }


### PR DESCRIPTION
Fixed migration to use proper ServerConfig enum with ConfigKey and ConfigValue identifiers instead of incorrect Alias names. Also changed value from numeric to string to match server_config table schema.