### PR TITLE
feat: Add homeworld system and planet limit based on astrophysics

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -57,6 +57,7 @@ mod m20260125_200002_seed_complete_expansion_data;
 mod m20260125_200003_fix_missing_time_columns;
 mod m20260126_000001_add_fleet_data_column;
 mod m20260121_000001_add_flight_speed_config;
+mod m20260121_000002_add_homeworld_system;
 
 pub struct Migrator;
 
@@ -121,6 +122,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260125_200003_fix_missing_time_columns::Migration),
             Box::new(m20260126_000001_add_fleet_data_column::Migration),
             Box::new(m20260121_000001_add_flight_speed_config::Migration),
+            Box::new(m20260121_000002_add_homeworld_system::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260121_000002_add_homeworld_system.rs
+++ b/backend/migration/src/m20260121_000002_add_homeworld_system.rs
@@ -1,0 +1,63 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add is_homeworld column to planet table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Planet::Table)
+                    .add_column(
+                        ColumnDef::new(Planet::IsHomeworld)
+                            .boolean()
+                            .not_null()
+                            .default(false)
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Mark the oldest planet for each user as homeworld
+        // This SQL query finds the first planet created by each user and marks it as homeworld
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            r#"
+            UPDATE planet p1
+            SET is_homeworld = true
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT id, owner_id,
+                           ROW_NUMBER() OVER (PARTITION BY owner_id ORDER BY created_at ASC) as rn
+                    FROM planet
+                ) as ranked
+                WHERE rn = 1
+            )
+            "#
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Planet::Table)
+                    .drop_column(Planet::IsHomeworld)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Planet {
+    Table,
+    IsHomeworld,
+}

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -174,7 +174,7 @@ let (system, position) = {
         (system, position)
     };
 
-    // Créer la planète
+    // Créer la planète (première planète = planète mère)
     let planet_id = Uuid::new_v4();
     let new_planet = planet::ActiveModel {
         id: Set(planet_id),
@@ -194,6 +194,7 @@ let (system, position) = {
         deuterium_amount: Set(500.0),
         last_update: Set(Utc::now().naive_utc()),
         created_at: Set(Utc::now().naive_utc()),
+        is_homeworld: Set(true), // Première planète = planète mère
         ..Default::default()
     };
 

--- a/backend/src/entities/planet.rs
+++ b/backend/src/entities/planet.rs
@@ -113,6 +113,10 @@ pub struct Model {
 
     // Date de création (pour déterminer la planète mère)
     pub created_at: DateTime,
+
+    // Planète mère (première planète du joueur)
+    #[sea_orm(default_value = false)]
+    pub is_homeworld: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3083,6 +3083,39 @@ async fn colonize_handler(
     let ships = att_planet_data.colony_ship_count;
     if ships < 1 { return (StatusCode::BAD_REQUEST, Json(json!({"error": "Aucun vaisseau de colonisation disponible"}))).into_response(); }
 
+    // Vérifier la limite de planètes basée sur astrophysique
+    let owner_id = att_planet_data.owner_id;
+
+    // Compter le nombre de planètes du joueur (sans la planète mère)
+    let planet_count = Planet::find()
+        .filter(planet::Column::OwnerId.eq(owner_id))
+        .filter(planet::Column::IsHomeworld.eq(false))
+        .count(&state.db)
+        .await
+        .unwrap_or(0);
+
+    // Récupérer le niveau d'astrophysique
+    let astrophysics_level = match tech_tree::get_player_tech_level(&state.db, owner_id, "astrophysics").await {
+        Ok(level) => level,
+        Err(_) => 0
+    };
+
+    // Calculer la limite de planètes (1 par niveau d'astrophysique, max 10)
+    let max_colonies = std::cmp::min(astrophysics_level as u64, 10);
+
+    if planet_count >= max_colonies {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": format!(
+                    "Limite de planètes atteinte ({}/{}). Recherchez l'Astrophysique pour coloniser plus de planètes.",
+                    planet_count,
+                    max_colonies
+                )
+            }))
+        ).into_response();
+    }
+
     // Récupérer les ressources à transporter (optionnelles)
     let metal_to_transport = payload.metal.unwrap_or(0.0).max(0.0);
     let crystal_to_transport = payload.crystal.unwrap_or(0.0).max(0.0);
@@ -3126,6 +3159,7 @@ async fn colonize_handler(
         deuterium_amount: Set(deuterium_to_transport),
         last_update: Set(Utc::now().naive_utc()),
         created_at: Set(Utc::now().naive_utc()),
+        is_homeworld: Set(false), // Les colonies ne sont jamais des planètes mères
         ..Default::default()
     };
 
@@ -3186,7 +3220,14 @@ async fn get_my_planets_handler(
     let current = Planet::find_by_id(current_id).one(&state.db).await.unwrap();
     
     if let Some(p) = current {
-        let my_planets = Planet::find().filter(planet::Column::OwnerId.eq(p.owner_id)).all(&state.db).await.unwrap_or_default();
+        let owner_id = p.owner_id;
+        let my_planets = Planet::find().filter(planet::Column::OwnerId.eq(owner_id)).all(&state.db).await.unwrap_or_default();
+
+        // Récupérer le niveau d'astrophysique pour calculer la limite
+        let astrophysics_level = tech_tree::get_player_tech_level(&state.db, owner_id, "astrophysics").await.unwrap_or(0);
+        let max_colonies = std::cmp::min(astrophysics_level, 10);
+        let colony_count = my_planets.iter().filter(|p| !p.is_homeworld).count();
+
         let list: Vec<serde_json::Value> = my_planets.into_iter().map(|mp| json!({
             "id": mp.id,
             "name": mp.name,
@@ -3194,6 +3235,7 @@ async fn get_my_planets_handler(
             "system": mp.system,
             "position": mp.position,
             "is_current": mp.id == current_id,
+            "is_homeworld": mp.is_homeworld,
             // Ressources
             "metal_amount": mp.metal_amount,
             "crystal_amount": mp.crystal_amount,
@@ -3219,7 +3261,13 @@ async fn get_my_planets_handler(
             "missile_launcher_count": mp.missile_launcher_count,
             "plasma_turret_count": mp.plasma_turret_count
         })).collect();
-        return Json(list).into_response();
+
+        return Json(json!({
+            "planets": list,
+            "colony_count": colony_count,
+            "max_colonies": max_colonies,
+            "astrophysics_level": astrophysics_level
+        })).into_response();
     }
     (StatusCode::UNAUTHORIZED, Json(json!({"error": "Planète introuvable"}))).into_response()
 }


### PR DESCRIPTION
Database changes:
- Add is_homeworld boolean field to planet table
- Migration automatically marks the oldest planet for each user as homeworld
- Update planet entity with is_homeworld field

Registration changes:
- First planet created during registration is now marked as homeworld (is_homeworld = true)

Colonization changes:
- Add planet limit check based on astrophysics technology
- Base limit: 0 colonies (only homeworld)
- Each level of astrophysics allows 1 additional colony (max 10)
- Colonies are always marked as is_homeworld = false
- Return clear error message when limit is reached

API changes:
- get_my_planets_handler now returns:
  - is_homeworld field for each planet
  - colony_count (number of non-homeworld planets)
  - max_colonies (based on astrophysics level)
  - astrophysics_level (current research level)

Game mechanics:
- Homeworld: The first planet, cannot be lost or colonized
- Colonies: Additional planets up to 10 maximum
- Astrophysics research unlocks planet slots (1 slot per level)
- Formula: Total planets = 1 homeworld + min(astrophysics_level, 10) colonies

This system encourages players to research astrophysics to expand their empire while maintaining a reasonable limit of 11 planets total per player.