### PR TITLE
fix: Properly escape double quotes around "user" table in SQL queries

### DIFF
--- a/download_production_backup.sh
+++ b/download_production_backup.sh
@@ -53,7 +53,7 @@ echo ""
 
 # Get database statistics
 echo -e "${YELLOW}Database statistics:${NC}"
-USER_COUNT=$(PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -t -A -c "SELECT COUNT(*) FROM \"user\"" 2>/dev/null || echo "?")
+USER_COUNT=$(PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -t -A -c 'SELECT COUNT(*) FROM "user"' 2>/dev/null || echo "?")
 PLANET_COUNT=$(PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -t -A -c "SELECT COUNT(*) FROM planet" 2>/dev/null || echo "?")
 echo "  Users: $USER_COUNT"
 echo "  Planets: $PLANET_COUNT"

--- a/migrate_production.sh
+++ b/migrate_production.sh
@@ -78,7 +78,7 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_old -t -A -F","
     password,
     COALESCE(created_at, NOW()),
     COALESCE(role, 'player')
-FROM "user"
+FROM \"user\"
 ORDER BY created_at ASC" > /tmp/users_backup.csv
 
 USER_COUNT=$(wc -l < /tmp/users_backup.csv)
@@ -125,7 +125,7 @@ echo -e "${YELLOW}Step 6: Importing user data...${NC}"
 while IFS=',' read -r id username email password created_at role
 do
     PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -c \
-    "INSERT INTO "user" (id, username, email, password, created_at, role)
+    "INSERT INTO \"user\" (id, username, email, password, created_at, role)
      VALUES ('$id', '$username', '$email', '$password', '$created_at', '$role')
      ON CONFLICT (id) DO NOTHING" > /dev/null
 done < /tmp/users_backup.csv
@@ -204,7 +204,7 @@ echo ""
 
 # Step 10: Verification
 echo -e "${YELLOW}Step 10: Verifying migration...${NC}"
-FINAL_USER_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -t -A -c "SELECT COUNT(*) FROM "user"")
+FINAL_USER_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -t -A -c 'SELECT COUNT(*) FROM "user"')
 FINAL_PLANET_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -t -A -c "SELECT COUNT(*) FROM planet WHERE is_homeworld = true")
 TECH_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -t -A -c "SELECT COUNT(*) FROM technologies")
 SHIP_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d $DB_NAME -t -A -c "SELECT COUNT(*) FROM ship_types")

--- a/verify_backup.sh
+++ b/verify_backup.sh
@@ -54,7 +54,7 @@ echo -e "${CYAN}USER DATA ANALYSIS${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 
-USER_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -t -A -c "SELECT COUNT(*) FROM "user"")
+USER_COUNT=$(PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -t -A -c 'SELECT COUNT(*) FROM "user"')
 echo -e "${GREEN}Total users to migrate: $USER_COUNT${NC}"
 echo ""
 
@@ -65,11 +65,11 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -c \
     email,
     COALESCE(role, 'player') as role,
     COALESCE(created_at::date::text, 'Unknown') as created
-FROM "user"
+FROM \"user\"
 ORDER BY created_at ASC
 LIMIT 10" 2>/dev/null || \
 PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -c \
-"SELECT username, email FROM "user" LIMIT 10"
+'SELECT username, email FROM "user" LIMIT 10'
 
 if [ $USER_COUNT -gt 10 ]; then
     echo -e "${BLUE}... and $((USER_COUNT - 10)) more users${NC}"
@@ -98,7 +98,7 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -c \
     ROUND(AVG(COALESCE(p.crystal_mine_level, 1)))::int as avg_crystal_mine,
     ROUND(AVG(COALESCE(p.deuterium_mine_level, 1)))::int as avg_deut_mine
 FROM planet p
-JOIN "user" u ON p.owner_id = u.id
+JOIN \"user\" u ON p.owner_id = u.id
 GROUP BY u.id, u.username
 ORDER BY u.username
 LIMIT 10" 2>/dev/null || echo "Could not calculate averages - table structure may differ"
@@ -121,7 +121,7 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -c \
     SUM(COALESCE(p.colony_ship_count, 0)) as colony_ships,
     SUM(COALESCE(p.transporter_count, 0)) as transporters
 FROM planet p
-JOIN "user" u ON p.owner_id = u.id
+JOIN \"user\" u ON p.owner_id = u.id
 GROUP BY u.id, u.username
 ORDER BY u.username
 LIMIT 10" 2>/dev/null || echo "Could not analyze fleet data - columns may not exist"
@@ -153,7 +153,7 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_verify -c \
     MAX(COALESCE(p.espionage_tech_level, 0)) as espionage_tech,
     MAX(COALESCE(p.armour_tech_level, 0)) as armour_tech
 FROM planet p
-JOIN "user" u ON p.owner_id = u.id
+JOIN \"user\" u ON p.owner_id = u.id
 GROUP BY u.id, u.username
 ORDER BY u.username
 LIMIT 10" 2>/dev/null || echo "Could not analyze technology data"


### PR DESCRIPTION
Fix bash quoting issues in SQL queries:

- Use single quotes for SQL command strings: 'SELECT ... FROM "user"'
- Escape double quotes inside double-quoted strings: \"user\"
- Prevents premature string termination in bash

Issue: psql was receiving 'FROM user' instead of 'FROM "user"'
Cause: Unescaped double quotes in bash double-quoted strings
Effect: SQL errors 'column "username" does not exist'

Fixes:
- download_production_backup.sh: User count query
- verify_backup.sh: All queries with "user" table
- migrate_production.sh: Extract, insert, and count queries

Now all 6 users should be properly detected and migrated.