### PR TITLE
fix: Use oldest planet by creation date instead of alphabetical order

### DIFF
--- a/fix_homeworld.sql
+++ b/fix_homeworld.sql
@@ -1,0 +1,28 @@
+-- Script pour corriger la planète mère (homeworld)
+-- Remplace "Kepler Alpha" par le nom de la planète que vous voulez comme homeworld
+
+BEGIN;
+
+-- 1. Retirer le statut homeworld de toutes les planètes de l'utilisateur 'phantomhex'
+UPDATE planet
+SET is_homeworld = false
+WHERE owner_id = (SELECT id FROM "user" WHERE username = 'phantomhex');
+
+-- 2. Mettre Kepler Alpha comme homeworld
+UPDATE planet
+SET is_homeworld = true
+WHERE owner_id = (SELECT id FROM "user" WHERE username = 'phantomhex')
+  AND name LIKE '%Kepler Alpha%';
+
+-- Vérifier le résultat
+SELECT
+    u.username,
+    p.name,
+    p.is_homeworld,
+    p.created_at
+FROM planet p
+JOIN "user" u ON p.owner_id = u.id
+WHERE u.username = 'phantomhex'
+ORDER BY p.is_homeworld DESC, p.created_at ASC;
+
+COMMIT;

--- a/migrate_production.sh
+++ b/migrate_production.sh
@@ -94,17 +94,24 @@ echo ""
 echo -e "${YELLOW}Step 3: Calculating planet resource averages per user...${NC}"
 PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USER -d space_db_old -t -A -F"," -c \
 "SELECT
-    owner_id,
-    ROUND(AVG(COALESCE(metal_amount, 0)))::bigint as avg_metal,
-    ROUND(AVG(COALESCE(crystal_amount, 0)))::bigint as avg_crystal,
-    ROUND(AVG(COALESCE(deuterium_amount, 0)))::bigint as avg_deuterium,
-    ROUND(AVG(COALESCE(metal_mine_level, 1)))::int as avg_metal_mine,
-    ROUND(AVG(COALESCE(crystal_mine_level, 1)))::int as avg_crystal_mine,
-    ROUND(AVG(COALESCE(deuterium_mine_level, 1)))::int as avg_deuterium_mine,
-    ROUND(AVG(COALESCE(solar_plant_level, 0)))::int as avg_solar_plant,
-    MIN(name) as first_planet_name
-FROM planet
-GROUP BY owner_id" > /tmp/planet_averages.csv
+    p1.owner_id,
+    ROUND(AVG(COALESCE(p2.metal_amount, 0)))::bigint as avg_metal,
+    ROUND(AVG(COALESCE(p2.crystal_amount, 0)))::bigint as avg_crystal,
+    ROUND(AVG(COALESCE(p2.deuterium_amount, 0)))::bigint as avg_deuterium,
+    ROUND(AVG(COALESCE(p2.metal_mine_level, 1)))::int as avg_metal_mine,
+    ROUND(AVG(COALESCE(p2.crystal_mine_level, 1)))::int as avg_crystal_mine,
+    ROUND(AVG(COALESCE(p2.deuterium_mine_level, 1)))::int as avg_deuterium_mine,
+    ROUND(AVG(COALESCE(p2.solar_plant_level, 0)))::int as avg_solar_plant,
+    (
+        SELECT name
+        FROM planet
+        WHERE owner_id = p1.owner_id
+        ORDER BY created_at ASC NULLS LAST, id ASC
+        LIMIT 1
+    ) as first_planet_name
+FROM (SELECT DISTINCT owner_id FROM planet) p1
+LEFT JOIN planet p2 ON p1.owner_id = p2.owner_id
+GROUP BY p1.owner_id" > /tmp/planet_averages.csv
 
 PLANET_DATA_COUNT=$(wc -l < /tmp/planet_averages.csv)
 echo -e "${GREEN}✓ Calculated averages for $PLANET_DATA_COUNT users${NC}"


### PR DESCRIPTION
Fix homeworld selection logic in migration:

Issue: Script chose 'Alpha Prime 756' instead of 'Kepler Alpha'
Cause: Used MIN(name) which selects alphabetically first planet
Fix: Use ORDER BY created_at ASC to select oldest planet

Changes:
- migrate_production.sh: Use subquery with ORDER BY created_at
- Add fix_homeworld.sql: Manual SQL script to correct homeworld

The migration now selects the first created planet as homeworld instead of the alphabetically first planet name.

For users who already migrated, run fix_homeworld.sql to manually correct the homeworld designation.