### PR TITLE
feat: Add Render production scripts for maintenance and compensation

### DIFF
--- a/RENDER_QUICKSTART.md
+++ b/RENDER_QUICKSTART.md
@@ -1,0 +1,270 @@
+# Guide Rapide - Appliquer sur Render
+
+## 🎯 Objectif
+
+Appliquer le patch de compensation et gérer la maintenance sur votre production Render.
+
+## 📋 Étapes Rapides
+
+### 1. Annoncer la Maintenance (Discord/Social)
+
+```
+🔧 MAINTENANCE PROGRAMMÉE
+
+Le serveur sera en maintenance dans 5 minutes pour une compensation suite à la migration.
+
+Bonus pour tous les joueurs:
+• +250,000 Métal 💎
+• +125,000 Cristal 💠
+• +75,000 Deutérium ⚡
+• +2 niveaux de mines ⛏️
+• +5 niveaux centrale solaire ☀️
+• Construction x300 plus rapide 🚀
+
+Durée: 5-10 minutes
+Début: [HEURE]
+
+Merci de votre patience !
+```
+
+### 2. Activer la Maintenance sur Render
+
+```bash
+chmod +x render_enable_maintenance.sh
+./render_enable_maintenance.sh "COMPENSATION JOUEURS" "10 minutes"
+```
+
+✅ Les joueurs voient maintenant la page Matrix de maintenance !
+
+### 3. Appliquer le Patch de Compensation
+
+```bash
+chmod +x render_apply_compensation.sh
+./render_apply_compensation.sh
+```
+
+Le script vous demandera confirmation, tapez `y`.
+
+**Ce que ça fait:**
+- ✅ +250K métal, +125K cristal, +75K deutérium
+- ✅ +2 niveaux mines
+- ✅ +5 niveaux centrale solaire
+- ✅ Vitesse construction x300
+
+**Durée:** ~5 secondes
+
+### 4. Vérifier les Résultats
+
+Le script affiche automatiquement:
+- Nombre de joueurs affectés
+- Ressources de chaque joueur
+- Niveaux de mines
+
+### 5. Désactiver la Maintenance
+
+```bash
+chmod +x render_disable_maintenance.sh
+./render_disable_maintenance.sh
+```
+
+✅ Les joueurs peuvent rejouer !
+
+### 6. Annoncer la Fin
+
+```
+✅ MAINTENANCE TERMINÉE
+
+Le serveur est de nouveau en ligne !
+
+Tous les joueurs ont reçu leurs compensations :
+• +250,000 Métal 💎
+• +125,000 Cristal 💠
+• +75,000 Deutérium ⚡
+• Mines améliorées ⛏️
+• Constructions 300x plus rapides 🚀
+
+Bon jeu ! 🚀
+```
+
+## 🔧 Scripts Disponibles
+
+| Script | Description |
+|--------|-------------|
+| `render_enable_maintenance.sh` | Active la maintenance sur Render |
+| `render_disable_maintenance.sh` | Désactive la maintenance sur Render |
+| `render_apply_compensation.sh` | Applique le patch de compensation |
+
+## 💡 Commandes Utiles
+
+### Vérifier le statut de maintenance
+
+```bash
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME \
+  -c "SELECT config_value FROM server_config WHERE config_key = 'maintenance_enabled';"
+```
+
+### Voir les ressources d'un joueur
+
+```bash
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME \
+  -c "SELECT u.username, p.metal_amount, p.crystal_amount, p.deuterium_amount
+      FROM planet p
+      JOIN \"user\" u ON p.owner_id = u.id
+      WHERE p.is_homeworld = true
+      ORDER BY u.username;"
+```
+
+### Voir les niveaux de mines
+
+```bash
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME \
+  -c "SELECT u.username, bt.building_key, pb.level
+      FROM planet_buildings pb
+      JOIN building_types bt ON pb.building_type_id = bt.id
+      JOIN planet p ON pb.planet_id = p.id
+      JOIN \"user\" u ON p.owner_id = u.id
+      WHERE p.is_homeworld = true
+        AND bt.building_key IN ('metal_mine', 'crystal_mine', 'deuterium_mine', 'solar_plant')
+      ORDER BY u.username, bt.building_key;"
+```
+
+## 🚨 En Cas de Problème
+
+### La maintenance ne s'active pas
+
+```bash
+# Vérifier la connexion
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME \
+  -c "SELECT 1"
+```
+
+### Le patch échoue
+
+```bash
+# Vérifier que la table existe
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME \
+  -c "\dt"
+```
+
+### Rollback du patch (si nécessaire)
+
+```bash
+# Retirer les bonus (à adapter selon vos besoins)
+source .env.migration
+PGPASSWORD=$SOURCE_DB_PASSWORD psql \
+  -h $SOURCE_DB_HOST \
+  -U $SOURCE_DB_USER \
+  -d $SOURCE_DB_NAME <<'EOF'
+BEGIN;
+UPDATE planet SET
+  metal_amount = metal_amount - 250000,
+  crystal_amount = crystal_amount - 125000,
+  deuterium_amount = deuterium_amount - 75000
+WHERE is_homeworld = true;
+
+UPDATE planet_buildings pb
+SET level = level - 2
+FROM building_types bt
+WHERE pb.building_type_id = bt.id
+  AND bt.building_key IN ('metal_mine', 'crystal_mine', 'deuterium_mine')
+  AND pb.planet_id IN (SELECT id FROM planet WHERE is_homeworld = true);
+
+UPDATE planet_buildings pb
+SET level = level - 5
+FROM building_types bt
+WHERE pb.building_type_id = bt.id
+  AND bt.building_key = 'solar_plant'
+  AND pb.planet_id IN (SELECT id FROM planet WHERE is_homeworld = true);
+COMMIT;
+EOF
+```
+
+## ⏱️ Timeline Recommandée
+
+| Temps | Action |
+|-------|--------|
+| T-10min | Annoncer maintenance sur Discord |
+| T-5min | Rappel de maintenance |
+| T-0min | Activer maintenance `render_enable_maintenance.sh` |
+| T+1min | Appliquer patch `render_apply_compensation.sh` |
+| T+2min | Vérifier résultats |
+| T+3min | Désactiver maintenance `render_disable_maintenance.sh` |
+| T+4min | Annoncer réouverture |
+| T+5min | Surveiller logs et feedback joueurs |
+
+## 📊 Exemple d'Exécution Complète
+
+```bash
+# 1. Activer maintenance
+./render_enable_maintenance.sh "COMPENSATION JOUEURS" "10 minutes"
+# ✓ Mode maintenance activé sur RENDER!
+
+# 2. Attendre 30 secondes (laisser les joueurs voir le message)
+sleep 30
+
+# 3. Appliquer patch
+./render_apply_compensation.sh
+# Êtes-vous sûr? [y/N] y
+# ✓ Patch appliqué avec succès!
+
+# 4. Désactiver maintenance
+./render_disable_maintenance.sh
+# ✓ Mode maintenance désactivé sur RENDER!
+```
+
+**Temps total:** ~2 minutes
+
+## 🎨 Personnaliser les Messages de Maintenance
+
+```bash
+# Message avec plusieurs lignes (séparé par |)
+./render_enable_maintenance.sh \
+  "GROSSE COMPENSATION" \
+  "5 minutes" \
+  "Compensation en cours...|+250K Métal|+125K Cristal|+75K Deutérium|Mines +2 niveaux|Centrale +5 niveaux|Construction x300|Merci de votre patience !"
+```
+
+## ✅ Checklist Finale
+
+**Avant:**
+- [ ] `.env.migration` correctement configuré avec credentials Render
+- [ ] Scripts rendus exécutables (`chmod +x`)
+- [ ] Annonce faite aux joueurs
+- [ ] Backend Render actif (pas besoin de l'arrêter)
+
+**Pendant:**
+- [ ] Maintenance activée
+- [ ] Patch appliqué
+- [ ] Résultats vérifiés
+
+**Après:**
+- [ ] Maintenance désactivée
+- [ ] Joueurs peuvent jouer
+- [ ] Annonce de réouverture
+- [ ] Surveillance des retours
+
+---
+
+**Temps total estimé:** 5-10 minutes
+**Risque:** Très faible (patch idempotent, rollback possible)
+**Impact:** Positif (joueurs contents des bonus)

--- a/render_apply_compensation.sh
+++ b/render_apply_compensation.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# ============================================================================
+# Appliquer le patch de compensation sur RENDER (Production)
+# ============================================================================
+
+set -e
+
+# Load environment variables
+if [ ! -f .env.migration ]; then
+    echo "ERROR: .env.migration file not found!"
+    exit 1
+fi
+
+source .env.migration
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+echo -e "${CYAN}============================================================================${NC}"
+echo -e "${CYAN}APPLICATION DU PATCH DE COMPENSATION SUR RENDER${NC}"
+echo -e "${CYAN}============================================================================${NC}"
+echo ""
+echo -e "${YELLOW}Ce patch va appliquer les bonus suivants à TOUS les joueurs:${NC}"
+echo "  ✅ +250,000 Métal"
+echo "  ✅ +125,000 Cristal"
+echo "  ✅ +75,000 Deutérium"
+echo "  ✅ +2 niveaux à toutes les mines"
+echo "  ✅ +5 niveaux à la centrale solaire"
+echo "  ✅ Vitesse de construction x300"
+echo ""
+echo -e "${YELLOW}Base de données cible:${NC}"
+echo "  Host: $SOURCE_DB_HOST"
+echo "  Database: $SOURCE_DB_NAME"
+echo ""
+
+# Confirmation
+read -p "$(echo -e ${BOLD}Êtes-vous sûr de vouloir appliquer ces bonus? [y/N]${NC} )" -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Opération annulée."
+    exit 0
+fi
+
+echo ""
+echo -e "${YELLOW}Connexion à Render...${NC}"
+
+# Test connection
+if ! PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -c "SELECT 1" > /dev/null 2>&1; then
+    echo -e "${RED}ERROR: Cannot connect to Render database!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Connecté${NC}"
+echo ""
+echo -e "${YELLOW}Application du patch...${NC}"
+
+# Apply compensation patch
+PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME <<'EOF'
+BEGIN;
+
+-- 1. Ajouter des ressources à toutes les planètes homeworld
+UPDATE planet
+SET
+    metal_amount = metal_amount + 250000,
+    crystal_amount = crystal_amount + 125000,
+    deuterium_amount = deuterium_amount + 75000
+WHERE is_homeworld = true;
+
+-- 2. Augmenter les niveaux de mines (+2 niveaux à toutes les mines)
+UPDATE planet_buildings pb
+SET level = level + 2
+FROM building_types bt
+WHERE pb.building_type_id = bt.id
+  AND bt.building_key IN ('metal_mine', 'crystal_mine', 'deuterium_mine')
+  AND pb.planet_id IN (SELECT id FROM planet WHERE is_homeworld = true);
+
+-- 3. Augmenter la centrale solaire (+5 niveaux)
+UPDATE planet_buildings pb
+SET level = level + 5
+FROM building_types bt
+WHERE pb.building_type_id = bt.id
+  AND bt.building_key = 'solar_plant'
+  AND pb.planet_id IN (SELECT id FROM planet WHERE is_homeworld = true);
+
+-- 4. Ajuster la vitesse de construction à 300
+INSERT INTO server_config (config_key, config_value, updated_at)
+VALUES ('construction_speed_multiplier', '300.0', NOW())
+ON CONFLICT (config_key) DO UPDATE
+SET config_value = '300.0', updated_at = NOW();
+
+-- Vérification
+SELECT '✓ Patch appliqué avec succès!' as message;
+
+SELECT
+    COUNT(DISTINCT p.owner_id) as joueurs_affectés
+FROM planet p
+WHERE p.is_homeworld = true;
+
+-- Afficher quelques résultats
+SELECT
+    u.username,
+    p.name,
+    p.metal_amount,
+    p.crystal_amount,
+    p.deuterium_amount,
+    (SELECT level FROM planet_buildings pb
+     JOIN building_types bt ON pb.building_type_id = bt.id
+     WHERE pb.planet_id = p.id AND bt.building_key = 'metal_mine' LIMIT 1) as metal_mine,
+    (SELECT level FROM planet_buildings pb
+     JOIN building_types bt ON pb.building_type_id = bt.id
+     WHERE pb.planet_id = p.id AND bt.building_key = 'solar_plant' LIMIT 1) as solar_plant
+FROM planet p
+JOIN "user" u ON p.owner_id = u.id
+WHERE p.is_homeworld = true
+ORDER BY u.username
+LIMIT 10;
+
+COMMIT;
+EOF
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}============================================================================${NC}"
+    echo -e "${GREEN}✅ PATCH APPLIQUÉ AVEC SUCCÈS SUR RENDER!${NC}"
+    echo -e "${GREEN}============================================================================${NC}"
+    echo ""
+    echo -e "${YELLOW}Tous les joueurs ont reçu les bonus de compensation.${NC}"
+    echo ""
+else
+    echo ""
+    echo -e "${RED}❌ ERREUR: Le patch n'a pas pu être appliqué!${NC}"
+    exit 1
+fi

--- a/render_disable_maintenance.sh
+++ b/render_disable_maintenance.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# ============================================================================
+# Désactiver le mode maintenance sur RENDER (Production)
+# ============================================================================
+
+set -e
+
+# Load environment variables
+if [ ! -f .env.migration ]; then
+    echo "ERROR: .env.migration file not found!"
+    exit 1
+fi
+
+source .env.migration
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${CYAN}============================================================================${NC}"
+echo -e "${CYAN}DÉSACTIVATION MAINTENANCE RENDER (PRODUCTION)${NC}"
+echo -e "${CYAN}============================================================================${NC}"
+echo ""
+echo -e "${YELLOW}Connexion à la base Render...${NC}"
+echo "  Host: $SOURCE_DB_HOST"
+echo "  Database: $SOURCE_DB_NAME"
+echo ""
+
+# Test connection
+if ! PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -c "SELECT 1" > /dev/null 2>&1; then
+    echo -e "${RED}ERROR: Cannot connect to Render database!${NC}"
+    exit 1
+fi
+
+# Deactivate maintenance
+PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME <<EOF
+-- Désactiver la maintenance
+UPDATE server_config SET config_value = 'false', updated_at = NOW() WHERE config_key = 'maintenance_enabled';
+
+-- Vérifier
+SELECT config_key, config_value FROM server_config WHERE config_key = 'maintenance_enabled';
+EOF
+
+echo ""
+echo -e "${GREEN}✅ Mode maintenance désactivé sur RENDER!${NC}"
+echo -e "${YELLOW}   Les joueurs peuvent maintenant accéder au jeu${NC}"
+echo ""

--- a/render_enable_maintenance.sh
+++ b/render_enable_maintenance.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# ============================================================================
+# Activer le mode maintenance sur RENDER (Production)
+# ============================================================================
+
+set -e
+
+# Load environment variables
+if [ ! -f .env.migration ]; then
+    echo "ERROR: .env.migration file not found!"
+    exit 1
+fi
+
+source .env.migration
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+TITLE="${1:-MAINTENANCE PROGRAMMÉE}"
+DURATION="${2:-15-30 minutes}"
+DESC="${3:-Le serveur est en maintenance pour une mise à jour majeure.|Vos comptes et ressources seront préservés.|Merci de votre patience !}"
+
+echo -e "${CYAN}============================================================================${NC}"
+echo -e "${CYAN}ACTIVATION MAINTENANCE RENDER (PRODUCTION)${NC}"
+echo -e "${CYAN}============================================================================${NC}"
+echo ""
+echo -e "${YELLOW}Connexion à la base Render...${NC}"
+echo "  Host: $SOURCE_DB_HOST"
+echo "  Database: $SOURCE_DB_NAME"
+echo ""
+echo -e "${YELLOW}Configuration:${NC}"
+echo "  Titre: $TITLE"
+echo "  Durée: $DURATION"
+echo ""
+
+# Test connection
+if ! PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME -c "SELECT 1" > /dev/null 2>&1; then
+    echo -e "${RED}ERROR: Cannot connect to Render database!${NC}"
+    exit 1
+fi
+
+# Activate maintenance
+PGPASSWORD=$SOURCE_DB_PASSWORD psql -h $SOURCE_DB_HOST -U $SOURCE_DB_USER -d $SOURCE_DB_NAME <<EOF
+-- Activer la maintenance
+UPDATE server_config SET config_value = 'true', updated_at = NOW() WHERE config_key = 'maintenance_enabled';
+
+-- Mettre à jour le message
+UPDATE server_config SET config_value = '$TITLE', updated_at = NOW() WHERE config_key = 'maintenance_message_title';
+UPDATE server_config SET config_value = '$DESC', updated_at = NOW() WHERE config_key = 'maintenance_message_description';
+UPDATE server_config SET config_value = '$DURATION', updated_at = NOW() WHERE config_key = 'maintenance_estimated_duration';
+UPDATE server_config SET config_value = NOW()::text, updated_at = NOW() WHERE config_key = 'maintenance_start_time';
+
+-- Vérifier
+SELECT config_key, config_value FROM server_config WHERE config_key LIKE 'maintenance_%' ORDER BY config_key;
+EOF
+
+echo ""
+echo -e "${GREEN}✅ Mode maintenance activé sur RENDER!${NC}"
+echo -e "${YELLOW}   Les joueurs verront la page de maintenance${NC}"
+echo ""


### PR DESCRIPTION
Add scripts to manage maintenance and apply compensation on Render:

Scripts:
- render_enable_maintenance.sh: Activate maintenance on Render
  * Uses SOURCE_DB credentials from .env.migration
  * Customizable title, duration, and description
  * Shows confirmation of activation

- render_disable_maintenance.sh: Deactivate maintenance on Render
  * Simple one-command deactivation
  * Immediate effect for all users

- render_apply_compensation.sh: Apply compensation patch on Render
  * +250,000 Metal for all players
  * +125,000 Crystal for all players
  * +75,000 Deuterium for all players
  * +2 levels to all mines
  * +5 levels to solar plant
  * Construction speed x300
  * Requires confirmation before applying
  * Shows affected players and results

Documentation:
- RENDER_QUICKSTART.md: Complete step-by-step guide
  * Timeline recommendation (10 min total)
  * Discord announcement templates
  * Useful verification commands
  * Troubleshooting section
  * Rollback procedures if needed

Usage:
1. ./render_enable_maintenance.sh "COMPENSATION" "10 min"
2. ./render_apply_compensation.sh (confirm with y)
3. ./render_disable_maintenance.sh

All scripts use .env.migration for Render credentials.