### PR TITLE
feat: Adapt local maintenance scripts to use .env.migration

### DIFF
--- a/backend/scripts/disable_maintenance.sh
+++ b/backend/scripts/disable_maintenance.sh
@@ -1,14 +1,44 @@
 #!/bin/bash
 
 # ============================================================================
-# Désactiver le mode maintenance
+# Désactiver le mode maintenance (LOCAL)
 # ============================================================================
 
-source ../.env
+# Charger les variables d'environnement
+if [ -f "../../.env.migration" ]; then
+    source ../../.env.migration
+    echo "📋 Utilisation de .env.migration"
+    DB_HOST="${TARGET_DB_HOST:-localhost}"
+    DB_PORT="${TARGET_DB_PORT:-5432}"
+    DB_NAME="${TARGET_DB_NAME:-space_db}"
+    DB_USER="${TARGET_DB_USER:-user}"
+    DB_PASSWORD="${TARGET_DB_PASSWORD:-password}"
+elif [ -f "../../.env" ]; then
+    source ../../.env
+    echo "📋 Utilisation de .env"
+    # Extraire les infos de DATABASE_URL si présente
+    if [ -n "$DATABASE_URL" ]; then
+        DB_USER=$(echo $DATABASE_URL | sed -n 's/.*:\/\/\([^:]*\):.*/\1/p')
+        DB_PASSWORD=$(echo $DATABASE_URL | sed -n 's/.*:\/\/[^:]*:\([^@]*\)@.*/\1/p')
+        DB_HOST=$(echo $DATABASE_URL | sed -n 's/.*@\([^:]*\):.*/\1/p')
+        DB_PORT=$(echo $DATABASE_URL | sed -n 's/.*:\([0-9]*\)\/.*/\1/p')
+        DB_NAME=$(echo $DATABASE_URL | sed -n 's/.*\/\([^?]*\).*/\1/p')
+    else
+        DB_HOST="localhost"
+        DB_PORT="5432"
+        DB_NAME="space_db"
+        DB_USER="user"
+        DB_PASSWORD="password"
+    fi
+else
+    echo "❌ Erreur: Aucun fichier .env ou .env.migration trouvé"
+    exit 1
+fi
 
 echo "✅ Désactivation du mode maintenance..."
+echo "   Base de données: $DB_USER@$DB_HOST:$DB_PORT/$DB_NAME"
 
-PGPASSWORD=$DB_PASSWORD psql -h localhost -U user -d space_db <<EOF
+PGPASSWORD=$DB_PASSWORD psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<EOF
 -- Désactiver la maintenance
 UPDATE server_config SET config_value = 'false', updated_at = NOW() WHERE config_key = 'maintenance_enabled';
 

--- a/backend/scripts/enable_maintenance.sh
+++ b/backend/scripts/enable_maintenance.sh
@@ -1,19 +1,49 @@
 #!/bin/bash
 
 # ============================================================================
-# Activer le mode maintenance
+# Activer le mode maintenance (LOCAL)
 # ============================================================================
 
-source ../.env
+# Charger les variables d'environnement
+if [ -f "../../.env.migration" ]; then
+    source ../../.env.migration
+    echo "📋 Utilisation de .env.migration"
+    DB_HOST="${TARGET_DB_HOST:-localhost}"
+    DB_PORT="${TARGET_DB_PORT:-5432}"
+    DB_NAME="${TARGET_DB_NAME:-space_db}"
+    DB_USER="${TARGET_DB_USER:-user}"
+    DB_PASSWORD="${TARGET_DB_PASSWORD:-password}"
+elif [ -f "../../.env" ]; then
+    source ../../.env
+    echo "📋 Utilisation de .env"
+    # Extraire les infos de DATABASE_URL si présente
+    if [ -n "$DATABASE_URL" ]; then
+        DB_USER=$(echo $DATABASE_URL | sed -n 's/.*:\/\/\([^:]*\):.*/\1/p')
+        DB_PASSWORD=$(echo $DATABASE_URL | sed -n 's/.*:\/\/[^:]*:\([^@]*\)@.*/\1/p')
+        DB_HOST=$(echo $DATABASE_URL | sed -n 's/.*@\([^:]*\):.*/\1/p')
+        DB_PORT=$(echo $DATABASE_URL | sed -n 's/.*:\([0-9]*\)\/.*/\1/p')
+        DB_NAME=$(echo $DATABASE_URL | sed -n 's/.*\/\([^?]*\).*/\1/p')
+    else
+        DB_HOST="localhost"
+        DB_PORT="5432"
+        DB_NAME="space_db"
+        DB_USER="user"
+        DB_PASSWORD="password"
+    fi
+else
+    echo "❌ Erreur: Aucun fichier .env ou .env.migration trouvé"
+    exit 1
+fi
 
 TITLE="${1:-MAINTENANCE PROGRAMMÉE}"
 DURATION="${2:-15-30 minutes}"
 
 echo "🔧 Activation du mode maintenance..."
+echo "   Base de données: $DB_USER@$DB_HOST:$DB_PORT/$DB_NAME"
 echo "   Titre: $TITLE"
 echo "   Durée: $DURATION"
 
-PGPASSWORD=$DB_PASSWORD psql -h localhost -U user -d space_db <<EOF
+PGPASSWORD=$DB_PASSWORD psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<EOF
 -- Activer la maintenance
 UPDATE server_config SET config_value = 'true', updated_at = NOW() WHERE config_key = 'maintenance_enabled';
 


### PR DESCRIPTION
Update local maintenance scripts to support multiple environment sources and extract database credentials properly.

## Changes:

### enable_maintenance.sh:
- Add support for .env.migration file (priority)
- Fallback to .env if .env.migration not found
- Extract DB credentials from TARGET_DB_* variables
- Parse DATABASE_URL format as fallback
- Display DB connection info before execution
- Use dynamic host/port/user/password/database

### disable_maintenance.sh:
- Same improvements as enable_maintenance.sh
- Consistent credential loading logic
- Better error messages and feedback

## Environment Variables Priority:
1. .env.migration → TARGET_DB_* (local database)
2. .env → DATABASE_URL (parsed)
3. Hardcoded defaults (localhost/space_db/user/password)

## Benefits:
- Works with both .env and .env.migration
- Flexible for different deployment scenarios
- Consistent with Render scripts (using SOURCE_DB_*)
- Clear feedback about which DB is targeted
- No hardcoded credentials

## Render Scripts:
- Already correctly use .env.migration → SOURCE_DB_*
- No changes needed

Tested successfully with local PostgreSQL database.