### PR TITLE
fix: Apply mining_speed_multiplier in production calculations and imp…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -592,9 +592,9 @@ export default function App() {
       .catch(console.error);
     if (token && planetId) {
       fetchPlanet();
-      // Polling réduit si WebSocket connecté (fallback uniquement)
-      // WebSocket = 10s polling, pas de WebSocket = 2s polling
-      const pollingInterval = wsConnected ? 10000 : 2000;
+      // Polling pour mises à jour en temps réel des ressources
+      // WebSocket = 5s polling (fallback), pas de WebSocket = 1s polling (temps réel)
+      const pollingInterval = wsConnected ? 5000 : 1000;
       const interval = setInterval(fetchPlanet, pollingInterval);
       return () => clearInterval(interval);
     }

--- a/frontend/src/components/ProductionStats.tsx
+++ b/frontend/src/components/ProductionStats.tsx
@@ -62,7 +62,8 @@ export default function ProductionStats({ planet, speedFactor = 10 }: { planet: 
     production_metal_growth: 1.1,
     production_crystal_growth: 1.1,
     production_deuterium_growth: 1.05,
-    energy_tech_bonus: 0.01
+    energy_tech_bonus: 0.01,
+    mining_speed_multiplier: 1.0
   });
 
   useEffect(() => {
@@ -160,12 +161,12 @@ export default function ProductionStats({ planet, speedFactor = 10 }: { planet: 
     const slotBonus = 1.0 + (activeSlots.length * 0.5);
     prod *= slotBonus;
 
-    // Speed factor
-    prod *= speedFactor;
+    // Speed factor ET mining speed multiplier
+    prod *= speedFactor * (config.mining_speed_multiplier || 1.0);
 
     return {
       total: Math.floor(prod),
-      base: Math.floor(baseFactor * level * Math.pow(growthFactor, level) * speedFactor),
+      base: Math.floor(baseFactor * level * Math.pow(growthFactor, level) * speedFactor * (config.mining_speed_multiplier || 1.0)),
       techBonus: techLevel,
       energyRatio: energyRatio,
       slotsCount: activeSlots.length,

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -74,7 +74,8 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
     energy_solar_growth: 1.1,
     energy_mine_consumption_base: 10,
     energy_mine_consumption_growth: 1.1,
-    energy_deuterium_extra_consumption: 20
+    energy_deuterium_extra_consumption: 20,
+    mining_speed_multiplier: 1.0
   });
 
   useEffect(() => {
@@ -232,8 +233,8 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
         prod *= slotBonus;
       }
 
-      // Appliquer le speed factor
-      prod *= speedFactor;
+      // Appliquer le speed factor ET le mining speed multiplier
+      prod *= speedFactor * (config.mining_speed_multiplier || 1.0);
 
       return Math.floor(prod);
   };


### PR DESCRIPTION
…rove polling

Production Fixes:
- ResourceDisplay.tsx: Multiply production by mining_speed_multiplier from config
- ProductionStats.tsx: Multiply production by mining_speed_multiplier from config
- Both components now correctly apply (speed_factor * mining_speed_multiplier)
- This matches backend calculation: (config.speed_factor / 100.0) * config.mining_speed

Backend uses:
- speed_factor (default 500) divided by 100 = 5x
- mining_speed (multiplier on top of speed_factor)
- Frontend now receives both and applies correctly

Polling Improvements:
- Reduced from 2s to 1s without WebSocket (better real-time feel)
- Reduced from 10s to 5s with WebSocket (faster fallback)
- Provides smoother resource updates for players

This fixes the issue where production displayed as '241/h' in x1000 mode because mining_speed_multiplier wasn't being applied.