### PR TITLE
fix: Add defenses object to GET /planets/:id endpoint

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1593,6 +1593,11 @@ async fn get_planet_handler(
         if let Ok(ship_details) = tech_tree::get_all_planet_ship_details(&state.db, updated_model.id).await {
             obj.insert("ships".into(), json!(ship_details));
         }
+
+        // Use detailed defense info for frontend display (includes count, name, stats)
+        if let Ok(defense_details) = tech_tree::get_all_planet_defense_details(&state.db, updated_model.id).await {
+            obj.insert("defenses".into(), json!(defense_details));
+        }
     }
 
     Ok(Json(json_response))


### PR DESCRIPTION
The PlanetOverview component was not displaying rocket launchers (and other defenses) because the GET /planets/:id endpoint was missing the defenses object in its response.

The endpoint was already returning:
- ships: All ship counts from planet_ships table
- buildings: All building levels from planet_buildings table
- technologies: All tech levels from planet_technologies table

But it was NOT returning:
- defenses: Defense counts from planet_defenses table

This caused getShipCount(planet, 'rocket_launcher') to return 0 even when the player had defenses built.

Changes:
- Added defenses object to the response using tech_tree::get_all_planet_defense_details()
- Now returns defense counts in the same format as ships: { "rocket_launcher": { count, name, attack, shield }, ... }

This fixes the Orbital Shield module showing 0 defenses when defenses actually exist on the planet.