### PR TITLE
fix: Prevent construction queue spam in Resources, Facilities, and De…

### DIFF
--- a/frontend/src/components/Defenses.tsx
+++ b/frontend/src/components/Defenses.tsx
@@ -40,6 +40,7 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
   const [defenseTypes, setDefenseTypes] = useState<DefenseTypeInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isBuilding, setIsBuilding] = useState(false);
 
   const fetchDefenseTypes = async () => {
     const token = localStorage.getItem('token');
@@ -119,8 +120,9 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
 
   const startBuild = async () => {
     const selectedDefense = defenseTypes.find(d => d.defense_key === selected);
-    if (!selectedDefense) return;
+    if (!selectedDefense || isBuilding) return;
 
+    setIsBuilding(true);
     try {
       const res = await fetch(apiUrl(`/planets/${planet.id}/build-defenses/${selected}/${qty}`), {
         method: 'POST',
@@ -144,6 +146,8 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
     } catch (e) {
       console.error(e);
       toast.error("Erreur de connexion");
+    } finally {
+      setIsBuilding(false);
     }
   };
 
@@ -167,7 +171,7 @@ export default function Defenses({ planet, onBuild }: { planet: any, onBuild: ()
 
   // Check prerequisites
   const isLocked = selectedDefense.requirements.some(req => !req.met);
-  const canBuild = !isBusy && canAfford && !isLocked;
+  const canBuild = !isBusy && !isBuilding && canAfford && !isLocked;
 
   const formatTime = (seconds: number) => {
     const h = Math.floor(seconds / 3600);

--- a/frontend/src/components/Facilities.tsx
+++ b/frontend/src/components/Facilities.tsx
@@ -311,7 +311,7 @@ export default function Facilities({ planet, onUpgrade }: FacilitiesProps) {
 
               <Button
                 onClick={() => handleUpgrade(building.building_key)}
-                disabled={locked || (isQueueFull && !activeItem) || !canAfford}
+                disabled={locked || !!activeItem || isQueueFull || !canAfford}
                 className={`w-full font-black uppercase tracking-widest transition-all duration-500 ${
                     activeItem
                         ? 'bg-indigo-900/50 border border-indigo-500 text-indigo-300 animate-pulse'

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -427,15 +427,15 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
 
               {/* BOUTON D'ACTION (Logique Multi-files + Design Riche Swipe) */}
               <div className="mt-auto">
-                <Button 
+                <Button
                   onClick={() => handleUpgrade(build.id)}
-                  disabled={(isQueueFull && !activeItem) || !canAfford}
+                  disabled={!!activeItem || isQueueFull || !canAfford}
                   className={`w-full h-10 font-black uppercase text-[10px] tracking-[0.2em] transition-all rounded-lg relative overflow-hidden group/btn ${
                     activeItem
-                      ? 'bg-slate-900 text-slate-300 border border-indigo-500/50' 
-                      : isQueueFull 
-                        ? 'bg-slate-900 text-slate-500 border border-white/5' 
-                        : !canAfford 
+                      ? 'bg-slate-900 text-slate-300 border border-indigo-500/50'
+                      : isQueueFull
+                        ? 'bg-slate-900 text-slate-500 border border-white/5'
+                        : !canAfford
                             ? 'bg-red-950/20 text-red-500 border border-red-900/30 cursor-not-allowed'
                             : `bg-black hover:bg-slate-900 text-white border ${theme.border} ${theme.glow}`
                   }`}


### PR DESCRIPTION
…fenses

Fixed upgrade/build buttons that remained clickable when items were already in the construction queue, allowing spam clicking.

Changes:
- ResourceDisplay.tsx: Added !!activeItem check to disabled prop
- Facilities.tsx: Added !!activeItem check to disabled prop
- Defenses.tsx: Added isBuilding state to prevent race conditions during API calls

The buttons are now properly disabled when:
- The item is already in the construction queue
- The queue is full (3 items)
- Resources are insufficient
- Requirements are not met (Facilities/Defenses only)