### PR TITLE
fix: Multiple bug fixes and spy report history feature

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -60,6 +60,7 @@ mod m20260121_000001_add_flight_speed_config;
 mod m20260121_000002_add_homeworld_system;
 mod m20260121_000003_add_maintenance_system;
 mod m20260127_000001_create_beginner_protection;
+mod m20260127_000002_fix_graviton_costs;
 
 pub struct Migrator;
 
@@ -127,6 +128,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260121_000002_add_homeworld_system::Migration),
             Box::new(m20260121_000003_add_maintenance_system::Migration),
             Box::new(m20260127_000001_create_beginner_protection::Migration),
+            Box::new(m20260127_000002_fix_graviton_costs::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260127_000002_fix_graviton_costs.rs
+++ b/backend/migration/src/m20260127_000002_fix_graviton_costs.rs
@@ -1,0 +1,48 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Fix Graviton technology costs - they were incorrectly set to 0
+        // This caused infinite free upgrades (0 * multiplier = 0)
+        //
+        // New values: Crystal: 5000, Deuterium: 3000
+        // With 3.0 multiplier, costs will scale properly:
+        // Level 1: 5000 C, 3000 D
+        // Level 2: 15000 C, 9000 D
+        // Level 3: 45000 C, 27000 D
+        // etc.
+        let db = manager.get_connection();
+
+        // Calculate base_time_seconds: (metal + crystal) / 2500 * 3600 = (0 + 5000) / 2500 * 3600 = 7200
+        db.execute_unprepared(
+            "UPDATE technologies SET \
+             base_cost_metal = 0, \
+             base_cost_crystal = 5000, \
+             base_cost_deuterium = 3000, \
+             base_time_seconds = 7200 \
+             WHERE tech_key = 'graviton_tech'"
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Revert to original (broken) values
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            "UPDATE technologies SET \
+             base_cost_metal = 0, \
+             base_cost_crystal = 0, \
+             base_cost_deuterium = 0, \
+             base_time_seconds = 0 \
+             WHERE tech_key = 'graviton_tech'"
+        ).await?;
+
+        Ok(())
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2845,11 +2845,43 @@ async fn spy_handler(
     }).to_string()));
     let _ = def_active.update(&state.db).await;
 
-    // Create a spy report in combat_log for the defender
+    // Create spy reports in combat_log for both attacker and defender
     let att_user = User::find_by_id(att_planet.owner_id).one(&state.db).await.unwrap();
+    let def_user = User::find_by_id(def_planet.owner_id).one(&state.db).await.unwrap();
     let attacker_username = att_user.map(|u| u.username.clone()).unwrap_or("Inconnu".to_string());
+    let defender_username = def_user.map(|u| u.username.clone()).unwrap_or("Inconnu".to_string());
 
-    let spy_log = combat_log::ActiveModel {
+    // Create detailed report JSON for the attacker's log
+    let spy_report_details = json!({
+        "type": "spy_report",
+        "target_planet": def_planet.name,
+        "target_player": defender_username,
+        "coordinates": format!("[{}:{}:{}]", def_planet.galaxy, def_planet.system, def_planet.position),
+        "tech_difference": tech_diff,
+        "detection_level": detection,
+        "resources": resources,
+        "fleet": fleet,
+        "defense": defense
+    });
+
+    // Create spy log for the ATTACKER (so they can review their spy reports)
+    let spy_log_attacker = combat_log::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        planet_id: Set(att_planet.id),
+        target_name: Set(def_planet.name.clone()),
+        opponent_username: Set(Some(defender_username.clone())),
+        mission_type: Set("spy_attack".to_string()),
+        result: Set("success".to_string()),
+        loot_metal: Set(0.0),
+        loot_crystal: Set(0.0),
+        ships_lost: Set(1), // 1 spy probe used
+        date: Set(Utc::now().naive_utc()),
+        detailed_report: Set(Some(spy_report_details)),
+    };
+    let _ = spy_log_attacker.insert(&state.db).await;
+
+    // Create spy log for the DEFENDER (alert notification)
+    let spy_log_defender = combat_log::ActiveModel {
         id: Set(Uuid::new_v4()),
         planet_id: Set(def_planet.id),
         target_name: Set(att_planet.name.clone()),
@@ -2860,9 +2892,14 @@ async fn spy_handler(
         loot_crystal: Set(0.0),
         ships_lost: Set(0),
         date: Set(Utc::now().naive_utc()),
-        detailed_report: Set(None), // Pas de détails de combat pour l'espionnage
+        detailed_report: Set(Some(json!({
+            "type": "spy_alert",
+            "attacker_planet": att_planet.name,
+            "attacker_player": attacker_username,
+            "coordinates": format!("[{}:{}:{}]", att_planet.galaxy, att_planet.system, att_planet.position)
+        }))),
     };
-    let _ = spy_log.insert(&state.db).await;
+    let _ = spy_log_defender.insert(&state.db).await;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // NOTIFICATION WEBSOCKET - Alerter le défenseur de l'espionnage
@@ -2996,11 +3033,43 @@ async fn spy_v2_handler(
     }).to_string()));
     let _ = def_active.update(&state.db).await;
 
-    // Create a spy report in combat_log for the defender
+    // Create spy reports in combat_log for both attacker and defender
     let att_user = User::find_by_id(att_planet.owner_id).one(&state.db).await.unwrap();
+    let def_user = User::find_by_id(def_planet.owner_id).one(&state.db).await.unwrap();
     let attacker_username = att_user.map(|u| u.username.clone()).unwrap_or("Inconnu".to_string());
+    let defender_username = def_user.map(|u| u.username.clone()).unwrap_or("Inconnu".to_string());
 
-    let spy_log = combat_log::ActiveModel {
+    // Create detailed report JSON for the attacker's log
+    let spy_report_details = json!({
+        "type": "spy_report",
+        "target_planet": def_planet.name,
+        "target_player": defender_username,
+        "coordinates": format!("[{}:{}:{}]", def_planet.galaxy, def_planet.system, def_planet.position),
+        "tech_difference": tech_diff,
+        "detection_level": detection,
+        "resources": resources,
+        "fleet": fleet,
+        "defense": defense
+    });
+
+    // Create spy log for the ATTACKER (so they can review their spy reports)
+    let spy_log_attacker = combat_log::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        planet_id: Set(att_planet.id),
+        target_name: Set(def_planet.name.clone()),
+        opponent_username: Set(Some(defender_username.clone())),
+        mission_type: Set("spy_attack".to_string()),
+        result: Set("success".to_string()),
+        loot_metal: Set(0.0),
+        loot_crystal: Set(0.0),
+        ships_lost: Set(1), // 1 spy probe used
+        date: Set(Utc::now().naive_utc()),
+        detailed_report: Set(Some(spy_report_details)),
+    };
+    let _ = spy_log_attacker.insert(&state.db).await;
+
+    // Create spy log for the DEFENDER (alert notification)
+    let spy_log_defender = combat_log::ActiveModel {
         id: Set(Uuid::new_v4()),
         planet_id: Set(def_planet.id),
         target_name: Set(att_planet.name.clone()),
@@ -3011,9 +3080,14 @@ async fn spy_v2_handler(
         loot_crystal: Set(0.0),
         ships_lost: Set(0),
         date: Set(Utc::now().naive_utc()),
-        detailed_report: Set(None), // Pas de détails de combat pour l'espionnage
+        detailed_report: Set(Some(json!({
+            "type": "spy_alert",
+            "attacker_planet": att_planet.name,
+            "attacker_player": attacker_username,
+            "coordinates": format!("[{}:{}:{}]", att_planet.galaxy, att_planet.system, att_planet.position)
+        }))),
     };
-    let _ = spy_log.insert(&state.db).await;
+    let _ = spy_log_defender.insert(&state.db).await;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // NOTIFICATION WEBSOCKET - Alerter le défenseur de l'espionnage

--- a/frontend/src/components/CombatModal.tsx
+++ b/frontend/src/components/CombatModal.tsx
@@ -136,6 +136,200 @@ export default function CombatModal({ report, onClose }: CombatModalProps) {
 
   if (!parsedReport) return null;
 
+  // --- CHECK FOR SPY REPORT ---
+  const isSpyReport = parsedReport.type === 'spy_report' || parsedReport.type === 'spy_alert';
+
+  if (isSpyReport) {
+    // Render spy report modal
+    return createPortal(
+      <div
+        className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/95 backdrop-blur-xl p-4 sm:p-6 overflow-y-auto"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        {/* Effets de fond */}
+        <div className="fixed inset-0 pointer-events-none overflow-hidden">
+          <div className="absolute top-0 left-1/4 w-96 h-96 rounded-full blur-[150px] opacity-30 bg-cyan-500" />
+          <div className="absolute bottom-0 right-1/4 w-80 h-80 rounded-full blur-[120px] opacity-20 bg-purple-500" />
+        </div>
+
+        <div
+          className="w-full max-w-2xl relative rounded-3xl border-2 border-cyan-500/50 bg-gradient-to-b from-cyan-900/30 via-slate-900 to-slate-950 shadow-[0_0_80px_rgba(6,182,212,0.3)] animate-in zoom-in-95 fade-in duration-300"
+          style={{ maxHeight: 'calc(100vh - 3rem)' }}
+        >
+          {/* HEADER */}
+          <div className="relative p-6 sm:p-8 border-b border-white/10 overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-cyan-900/50 to-transparent" />
+
+            <div className="relative flex justify-between items-start gap-4">
+              <div className="flex items-center gap-4 sm:gap-6">
+                <div className="relative p-4 sm:p-5 rounded-2xl bg-black/60 border border-white/20 shadow-2xl text-cyan-400">
+                  <Target size={40} className="sm:w-12 sm:h-12 drop-shadow-[0_0_20px_currentColor]" />
+                </div>
+
+                <div>
+                  <h2 className="text-3xl sm:text-4xl font-black uppercase tracking-tight text-cyan-400 drop-shadow-lg">
+                    {parsedReport.type === 'spy_report' ? 'RAPPORT D\'ESPIONNAGE' : 'ESPIONNAGE DÉTECTÉ'}
+                  </h2>
+                  <div className="flex flex-wrap items-center gap-3 mt-3">
+                    <span className="text-xs bg-white/10 px-3 py-1.5 rounded-full font-mono text-slate-300 border border-white/10 flex items-center gap-2">
+                      <MapPin size={12} />
+                      {parsedReport.coordinates || 'Coordonnées inconnues'}
+                    </span>
+                    <span className="text-sm font-bold text-purple-400 uppercase tracking-wider flex items-center gap-2">
+                      <User size={16} className="text-slate-500"/>
+                      {parsedReport.type === 'spy_report' ? parsedReport.target_player : parsedReport.attacker_player || 'Inconnu'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={onClose}
+                className="text-white/50 hover:text-white hover:bg-white/10 transition-all p-3 rounded-xl shrink-0"
+              >
+                <X size={28} />
+              </button>
+            </div>
+          </div>
+
+          {/* CONTENU SCROLLABLE */}
+          <div
+            className="p-6 sm:p-8 space-y-6 overflow-y-auto"
+            style={{ maxHeight: 'calc(100vh - 20rem)' }}
+          >
+            {/* INFO TECHNIQUE */}
+            {parsedReport.type === 'spy_report' && (
+              <div className="bg-slate-800/50 border border-white/10 p-4 rounded-xl">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-slate-400 uppercase">Niveau de détection</span>
+                  <span className={`text-sm font-bold uppercase px-3 py-1 rounded-full ${
+                    parsedReport.detection_level === 'full' ? 'bg-emerald-500/20 text-emerald-400' :
+                    parsedReport.detection_level === 'fleet' ? 'bg-yellow-500/20 text-yellow-400' :
+                    parsedReport.detection_level === 'resources' ? 'bg-orange-500/20 text-orange-400' :
+                    'bg-red-500/20 text-red-400'
+                  }`}>
+                    {parsedReport.detection_level === 'full' ? '🔍 SCAN COMPLET' :
+                     parsedReport.detection_level === 'fleet' ? '🛸 FLOTTE DÉTECTÉE' :
+                     parsedReport.detection_level === 'resources' ? '📦 RESSOURCES SEULEMENT' :
+                     '❌ ÉCHEC'}
+                  </span>
+                </div>
+                {parsedReport.tech_difference !== undefined && (
+                  <div className="mt-3 text-xs text-slate-500">
+                    Différence technologique: <span className={`font-bold ${parsedReport.tech_difference >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {parsedReport.tech_difference >= 0 ? '+' : ''}{parsedReport.tech_difference}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* RESSOURCES DÉTECTÉES */}
+            {parsedReport.resources && (
+              <section className="space-y-4">
+                <h3 className="text-xs font-black text-slate-400 uppercase tracking-[0.3em] flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-yellow-500/20">
+                    <Box size={14} className="text-yellow-400" />
+                  </div>
+                  Ressources détectées
+                </h3>
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="bg-orange-500/10 border border-orange-500/30 p-4 rounded-xl text-center">
+                    <Box size={20} className="text-orange-400 mx-auto mb-2" />
+                    <div className="text-xl font-mono font-black text-orange-400">
+                      {Math.floor(parsedReport.resources.metal || 0).toLocaleString()}
+                    </div>
+                    <div className="text-[10px] font-bold uppercase text-slate-500">Métal</div>
+                  </div>
+                  <div className="bg-cyan-500/10 border border-cyan-500/30 p-4 rounded-xl text-center">
+                    <Gem size={20} className="text-cyan-400 mx-auto mb-2" />
+                    <div className="text-xl font-mono font-black text-cyan-400">
+                      {Math.floor(parsedReport.resources.crystal || 0).toLocaleString()}
+                    </div>
+                    <div className="text-[10px] font-bold uppercase text-slate-500">Cristal</div>
+                  </div>
+                  <div className="bg-green-500/10 border border-green-500/30 p-4 rounded-xl text-center">
+                    <Droplets size={20} className="text-green-400 mx-auto mb-2" />
+                    <div className="text-xl font-mono font-black text-green-400">
+                      {Math.floor(parsedReport.resources.deuterium || 0).toLocaleString()}
+                    </div>
+                    <div className="text-[10px] font-bold uppercase text-slate-500">Deutérium</div>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {/* FLOTTE DÉTECTÉE */}
+            {parsedReport.fleet && Object.keys(parsedReport.fleet).length > 0 && (
+              <section className="space-y-4">
+                <h3 className="text-xs font-black text-slate-400 uppercase tracking-[0.3em] flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-purple-500/20">
+                    <Rocket size={14} className="text-purple-400" />
+                  </div>
+                  Flotte détectée
+                </h3>
+                <div className="bg-slate-800/50 border border-white/10 rounded-xl p-4 space-y-2 max-h-60 overflow-y-auto">
+                  {Object.entries(parsedReport.fleet).filter(([_, count]) => (count as number) > 0).map(([shipKey, count]) => (
+                    <div key={shipKey} className="flex items-center justify-between p-2 bg-slate-700/30 rounded-lg">
+                      <div className="flex items-center gap-2">
+                        <Rocket size={14} className="text-slate-400" />
+                        <span className="text-sm text-white">{getShipDisplayName(shipKey)}</span>
+                      </div>
+                      <span className="font-mono font-bold text-purple-400">{(count as number).toLocaleString()}</span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* DÉFENSES */}
+            {parsedReport.defense !== undefined && parsedReport.defense !== null && (
+              <section className="space-y-4">
+                <h3 className="text-xs font-black text-slate-400 uppercase tracking-[0.3em] flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-red-500/20">
+                    <Shield size={14} className="text-red-400" />
+                  </div>
+                  Défenses totales
+                </h3>
+                <div className="bg-red-500/10 border border-red-500/30 p-4 rounded-xl text-center">
+                  <Shield size={24} className="text-red-400 mx-auto mb-2" />
+                  <div className="text-3xl font-mono font-black text-red-400">
+                    {parsedReport.defense.toLocaleString()}
+                  </div>
+                  <div className="text-[10px] font-bold uppercase text-slate-500">Unités de défense</div>
+                </div>
+              </section>
+            )}
+
+            {/* ALERT INFO (for defender) */}
+            {parsedReport.type === 'spy_alert' && (
+              <div className="bg-purple-500/10 border border-purple-500/30 p-4 rounded-xl text-center">
+                <AlertCircle size={32} className="text-purple-400 mx-auto mb-3" />
+                <p className="text-sm text-slate-300">
+                  Votre planète a été espionnée par <span className="font-bold text-purple-400">{parsedReport.attacker_player || 'un joueur inconnu'}</span>
+                </p>
+                <p className="text-xs text-slate-500 mt-2">
+                  Depuis: {parsedReport.attacker_planet || 'planète inconnue'}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* FOOTER */}
+          <div className="p-6 sm:p-8 border-t border-white/10 bg-black/30">
+            <Button
+              onClick={onClose}
+              className="w-full h-14 text-lg font-black uppercase tracking-widest transition-all rounded-xl bg-gradient-to-r from-cyan-600 to-purple-500 hover:from-cyan-500 hover:to-purple-400 shadow-xl hover:scale-[1.02] hover:shadow-2xl"
+            >
+              Fermer le rapport
+            </Button>
+          </div>
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
   // --- NORMALISATION ---
   const missionType = parsedReport.mission_type || 'attack';
   const isExpedition = missionType === 'expedition';

--- a/frontend/src/components/Facilities.tsx
+++ b/frontend/src/components/Facilities.tsx
@@ -181,7 +181,9 @@ export default function Facilities({ planet, onUpgrade }: FacilitiesProps) {
   };
 
   const queue = planet.constructions || [];
-  const isQueueFull = queue.length >= 3;
+  const shipBuilds = planet.ship_builds || [];
+  const defenseBuilds = planet.defense_builds || [];
+  const isQueueFull = queue.length + shipBuilds.length + defenseBuilds.length >= 3;
 
   if (loading) {
     return (

--- a/frontend/src/components/PlanetOverview.tsx
+++ b/frontend/src/components/PlanetOverview.tsx
@@ -317,7 +317,7 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
     }))
   ].sort((a, b) => new Date(a.end_time).getTime() - new Date(b.end_time).getTime());
 
-  const slotsUsed = buildingQueue.length; // Only buildings/tech count towards the 3-slot limit
+  const slotsUsed = constructionQueue.length; // All constructions (buildings, ships, defenses) count towards the 3-slot limit
   const maxSlots = 3;
 
   // --- MISSIONS (Backend enrichit l'objet planet avec ces listes) ---

--- a/frontend/src/components/ReportsTerminal.tsx
+++ b/frontend/src/components/ReportsTerminal.tsx
@@ -199,10 +199,14 @@ export default function ReportsTerminal({ planetId }: { planetId: string }) {
                         );
                     }
 
-                    // Rapport d'espionnage
+                    // Rapport d'espionnage détecté (défenseur)
                     if (isSpy) {
                         return (
-                            <div key={log.id} className="bg-purple-950/10 border border-purple-500/30 p-3 rounded-lg flex items-center justify-between group hover:bg-purple-950/20 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg animate-fade-in card-depth">
+                            <div
+                                key={log.id}
+                                onClick={() => handleReportClick(log.id)}
+                                className="bg-purple-950/10 border border-purple-500/30 p-3 rounded-lg flex items-center justify-between group hover:bg-purple-950/20 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg cursor-pointer animate-fade-in card-depth"
+                            >
                                 <div className="flex items-center gap-4">
                                     <div className="p-2 rounded-lg bg-purple-500/20 text-purple-400">
                                         <ShieldAlert size={16} />
@@ -210,7 +214,7 @@ export default function ReportsTerminal({ planetId }: { planetId: string }) {
                                     <div>
                                         <div className="flex items-center gap-2">
                                             <span className="text-xs font-black uppercase text-purple-400">
-                                                ESPIONNAGE DÉTECTÉ
+                                                🔍 ESPIONNAGE DÉTECTÉ
                                             </span>
                                             <span className="text-[10px] text-slate-500 font-mono">
                                                 par {log.opponent_username || "Inconnu"}
@@ -224,6 +228,45 @@ export default function ReportsTerminal({ planetId }: { planetId: string }) {
                                 <div className="text-right">
                                     <div className="text-[10px] text-purple-300 font-mono">
                                         Source: {log.target_name}
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    }
+
+                    // Rapport d'espionnage envoyé (attaquant)
+                    const isSpyAttack = log.mission_type === 'spy_attack';
+                    if (isSpyAttack) {
+                        return (
+                            <div
+                                key={log.id}
+                                onClick={() => handleReportClick(log.id)}
+                                className="bg-cyan-950/10 border border-cyan-500/30 p-3 rounded-lg flex items-center justify-between group hover:bg-cyan-950/20 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg cursor-pointer animate-fade-in card-depth"
+                            >
+                                <div className="flex items-center gap-4">
+                                    <div className="p-2 rounded-lg bg-cyan-500/20 text-cyan-400">
+                                        <ArrowUpRight size={16} />
+                                    </div>
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-xs font-black uppercase text-cyan-400">
+                                                🛰️ RAPPORT D'ESPIONNAGE
+                                            </span>
+                                            <span className="text-[10px] text-slate-500 font-mono">
+                                                sur {log.opponent_username || "Inconnu"}
+                                            </span>
+                                        </div>
+                                        <div className="text-[10px] text-cyan-300 mt-0.5">
+                                            Cible: {log.target_name}
+                                        </div>
+                                        <div className="text-[10px] text-slate-400 mt-0.5">
+                                            {formatDate(log.date)}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="text-right">
+                                    <div className="text-[10px] text-cyan-300 font-mono">
+                                        Cliquez pour voir les détails
                                     </div>
                                 </div>
                             </div>

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -292,7 +292,9 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
   
   // LOGIQUE QUEUE MULTIPLE
   const queue = planet.constructions || [];
-  const isQueueFull = queue.length >= 3;
+  const shipBuilds = planet.ship_builds || [];
+  const defenseBuilds = planet.defense_builds || [];
+  const isQueueFull = queue.length + shipBuilds.length + defenseBuilds.length >= 3;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 animate-in fade-in slide-in-from-bottom-4 duration-700 pb-20">

--- a/frontend/src/components/TechTree.tsx
+++ b/frontend/src/components/TechTree.tsx
@@ -132,7 +132,9 @@ export default function TechTree({ planet, onUpdate }: { planet: any, onUpdate: 
 
   // --- LOGIQUE FILE D'ATTENTE MULTIPLE ---
   const queue = planet.constructions || [];
-  const isQueueFull = queue.length >= 3;
+  const shipBuilds = planet.ship_builds || [];
+  const defenseBuilds = planet.defense_builds || [];
+  const isQueueFull = queue.length + shipBuilds.length + defenseBuilds.length >= 3;
 
   if (loading) {
     return (

--- a/frontend/src/components/TechTreeVisual.tsx
+++ b/frontend/src/components/TechTreeVisual.tsx
@@ -251,7 +251,9 @@ export default function TechTreeVisual({ planet, onUpdate }: TechTreeVisualProps
   const [loading, setLoading] = useState(true);
 
   const queue = planet.constructions || [];
-  const isQueueFull = queue.length >= 3;
+  const shipBuilds = planet.ship_builds || [];
+  const defenseBuilds = planet.defense_builds || [];
+  const isQueueFull = queue.length + shipBuilds.length + defenseBuilds.length >= 3;
 
   const metal = planet.metal_amount ?? 0;
   const crystal = planet.crystal_amount ?? 0;


### PR DESCRIPTION
Bug fixes:
- Production chain now correctly shows all slots used (buildings + ships + defenses) Fixed in: PlanetOverview, Facilities, ResourceDisplay, TechTree, TechTreeVisual
- Graviton technology now has proper costs (5000 crystal, 3000 deuterium) Previously had 0 costs allowing infinite free upgrades

New feature:
- Spy reports are now saved with full details for both attacker and defender
- Attacker can review their spy reports in the Reports Terminal
- New spy report modal shows: resources, fleet, defenses, tech difference
- Reports have mission_type "spy_attack" for attacker, "spy_defense" for defender