### PR TITLE
fix: Resource deductions hidden, raw seconds in queue, research lab key

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1858,7 +1858,7 @@ async fn upgrade_mine_handler(
             deuterium: deuterium as f64,
         };
 
-        let research_lab_level = tech_tree::get_planet_building_level(&state.db, p.id, "research").await.unwrap_or(0);
+        let research_lab_level = tech_tree::get_planet_building_level(&state.db, p.id, "research_lab").await.unwrap_or(0);
         (current_level, cost, research_lab_level, true)
     } else {
         // Check if this is a building from the new system

--- a/frontend/public/changelog.md
+++ b/frontend/public/changelog.md
@@ -1,5 +1,22 @@
 # Changelog - Space Conquest
 
+## [3.7.0] - 2026-03-06 - Succès & ressources
+
+### 🐛 Corrections
+
+#### 🏆 Succès — progrès jamais sauvegardé (bug critique)
+- **Bug** : `update_achievement_progress` appelait `.update()` pour les *nouveaux* enregistrements car `active.id.is_set()` retourne `true` dans les deux cas (Sea-ORM encode `Model::into()` en `Set(...)`). Résultat : toute progression (expéditions, attaques, bâtiments...) restait éternellement à 0/N.
+- **Fix** : suivi explicite d'un booléen `is_new` pour choisir `.insert()` vs `.update()`.
+
+#### 📊 Barre de ressources — déductions invisibles
+- **Bug** : la protection anti-oscillation (`Math.max`) dans `useRealtimeResources` empêchait les déductions de ressources de s'afficher dans la barre en haut — après construction de défenses/vaisseaux/recherches, les ressources semblaient ne pas diminuer.
+- **Fix** : comparaison avec la valeur serveur *précédente* pour distinguer une déduction (valeur serveur en baisse) d'un simple lag de polling.
+
+#### 🔬 Temps de recherche — niveau labo ignoré
+- La clé `"research"` ne correspondait pas à la clé DB `"research_lab"` → le bonus de réduction de temps du labo de recherche était ignoré pour tous les calculs de durée.
+
+---
+
 ## [3.6.0] - 2026-03-06 - Score, énergie & défenses
 
 ### 🐛 Corrections

--- a/frontend/src/components/ExpeditionZone.tsx
+++ b/frontend/src/components/ExpeditionZone.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getTechLevel, getShipCount } from '@/utils/techTreeCompat';
+import { formatDuration } from '@/lib/utils';
 import { Compass, Timer, Send, AlertTriangle, Database, Rocket, Map, Radar, ScanLine, Minus, Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -415,7 +416,7 @@ export default function ExpeditionZone({ planet, onAction }: { planet: any, onAc
                    <span className="flex items-center gap-3 text-cyan-400">
                      <Timer size={20} className="animate-spin" /> MISSION EN COURS
                    </span>
-                   <span className="text-2xl font-mono text-white mt-1">{timeLeft}s</span>
+                   <span className="text-2xl font-mono text-white mt-1">{formatDuration(timeLeft)}</span>
                 </div>
               ) : !hasShips ? (
                 "VAISSEAU REQUIS POUR DÉCOLLAGE"

--- a/frontend/src/components/ExpeditionZoneV2.tsx
+++ b/frontend/src/components/ExpeditionZoneV2.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Compass, Timer, Send, AlertTriangle, Database, Rocket, Map, Radar, ScanLine, Minus, Plus, Zap } from "lucide-react";
+import { formatDuration } from '@/lib/utils';
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { toast } from "sonner";
@@ -372,7 +373,7 @@ export default function ExpeditionZoneV2({ planet, onAction }: { planet: any, on
                    <span className="flex items-center gap-3 text-cyan-400">
                      <Timer size={20} className="animate-spin" /> MISSION EN COURS
                    </span>
-                   <span className="text-2xl font-mono text-white mt-1">{timeLeft}s</span>
+                   <span className="text-2xl font-mono text-white mt-1">{formatDuration(timeLeft)}</span>
                 </div>
               ) : !hasShips ? (
                 "VAISSEAU REQUIS POUR DÉCOLLAGE"

--- a/frontend/src/components/Facilities.tsx
+++ b/frontend/src/components/Facilities.tsx
@@ -419,7 +419,7 @@ export default function Facilities({ planet, onUpgrade }: FacilitiesProps) {
                 }`}
               >
                 {activeItem ? (
-                    <span className="flex items-center gap-2"><Timer size={16} className="animate-spin" /> En cours: {timeLeft}s</span>
+                    <span className="flex items-center gap-2"><Timer size={16} className="animate-spin" /> En cours: {formatDuration(timeLeft ?? 0)}</span>
                 ) : locked ? (
                     "Accès Refusé"
                 ) : isQueueFull ? (

--- a/frontend/src/components/PlanetOverview.tsx
+++ b/frontend/src/components/PlanetOverview.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { apiUrl } from '@/config/api';
 import { useRealtimeResources } from '@/hooks/useRealtimeResources';
 import { getTechLevel, getBuildingLevel, getShipCount, calculateFleetAttack, calculateFleetHull, getTotalFleetCount } from '@/utils/techTreeCompat';
+import { formatDuration } from '@/lib/utils';
 // --- Dictionnaire de noms ---
 const getLabel = (id: string | null) => {
     if (!id) return "Inconnu";
@@ -394,7 +395,7 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
                                       </div>
                                       <div className="text-right">
                                           <div className={`font-mono text-lg font-black ${isAttack ? 'text-red-400' : 'text-white'}`}>
-                                              {tl}s
+                                              {formatDuration(tl)}
                                           </div>
                                           <div className="text-[9px] font-mono text-slate-500">
                                               {m.ships_count} Unités
@@ -452,7 +453,7 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
                         </div>
                         <div className="text-right">
                             <span className="text-sm font-mono font-black text-white bg-black px-2 py-1 rounded border border-white/10 shadow-inner">
-                                {tl}s
+                                {formatDuration(tl)}
                             </span>
                         </div>
                     </div>
@@ -591,7 +592,7 @@ export default function PlanetOverview({ planet, speedFactor }: { planet: any, s
                                             <div className="flex items-center gap-2.5">
                                                 <div className={`flex items-center gap-2 ${index === 0 ? 'text-cyan-300' : 'text-indigo-300'} font-mono bg-black/60 px-3 py-1.5 rounded-lg border-2 ${index === 0 ? 'border-cyan-500/50 shadow-[0_0_10px_rgba(6,182,212,0.3)]' : 'border-indigo-500/30'}`}>
                                                     <Clock size={12} className={index === 0 ? "animate-spin-slow drop-shadow-[0_0_6px_rgba(6,182,212,0.8)]" : ""} />
-                                                    <span className="font-black text-sm">{tl}s</span>
+                                                    <span className="font-black text-sm">{formatDuration(tl)}</span>
                                                 </div>
                                                 {/* Cancel button for all queue items */}
                                                 <div className="relative group/cancel">

--- a/frontend/src/components/ResourceDisplay.tsx
+++ b/frontend/src/components/ResourceDisplay.tsx
@@ -24,6 +24,7 @@ import { toast } from "sonner";
 import { GameImage } from '@/components/ui/game-image';
 import { getResourceImage } from '@/lib/images';
 import { getTechLevel, getBuildingLevel } from '@/utils/techTreeCompat';
+import { formatDuration } from '@/lib/utils';
 
 interface ResourceSlot {
   id: number;
@@ -501,7 +502,7 @@ export default function ResourceDisplay({ planet, onUpgrade, speedFactor = 10 }:
 
                   {activeItem ? (
                      <span className="flex items-center gap-2 relative z-10 text-cyan-400">
-                       <Timer size={14} className="animate-spin-slow" /> En cours {timeLeft}s
+                       <Timer size={14} className="animate-spin-slow" /> En cours {formatDuration(timeLeft ?? 0)}
                      </span>
                   ) : isQueueFull ? (
                     <span className="relative z-10">File Pleine (3/3)</span>

--- a/frontend/src/components/Shipyard.tsx
+++ b/frontend/src/components/Shipyard.tsx
@@ -360,7 +360,7 @@ export default function Shipyard({ planet, onUpdate }: ShipyardProps) {
                     <Button onClick={() => buildShip(ship.ship_key)} disabled={locked || isQueueFull || !canAfford || (qty[ship.ship_key] || 0) <= 0 || isFull} className={`flex-1 h-10 font-black uppercase text-[10px] tracking-[0.2em] transition-all rounded-lg relative overflow-hidden group/btn ${isQueueFull ? 'bg-slate-800 text-slate-500 border border-slate-700' : isFull ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : !canAfford ? 'bg-red-950/20 text-red-500 border border-red-900/40 cursor-not-allowed' : `bg-black hover:bg-slate-900 text-white border ${theme.border} hover:shadow-[0_0_20px_rgba(255,255,255,0.1)]`}`}>
                         {activeItem ? (
                              <span className="flex items-center gap-2 relative z-10 text-orange-300">
-                                <Timer size={14} className="animate-spin" /> En cours ({timeLeft}s)
+                                <Timer size={14} className="animate-spin" /> En cours ({formatDuration(timeLeft ?? 0)})
                              </span>
                         ) : isQueueFull ? (
                             <span className="relative z-10">File Pleine</span>

--- a/frontend/src/hooks/useRealtimeResources.ts
+++ b/frontend/src/hooks/useRealtimeResources.ts
@@ -49,6 +49,7 @@ export function useRealtimeResources(
   const [resources, setResources] = useState<RealtimeResources | null>(null);
   const lastUpdateRef = useRef<number>(Date.now());
   const baseResourcesRef = useRef<RealtimeResources | null>(null);
+  const prevServerRef = useRef<RealtimeResources | null>(null);
 
   // Valeurs par défaut si config n'est pas fournie
   const safeConfig = config || {
@@ -158,15 +159,27 @@ export function useRealtimeResources(
       deutSlotBonus
     );
 
-    // Sauvegarder les ressources de base — ne pas reculer en dessous de la valeur déjà affichée
-    const prevResources = baseResourcesRef.current;
+    // Sauvegarder les ressources de base.
+    // - Si le serveur rapporte une valeur INFÉRIEURE à la dernière valeur serveur connue
+    //   (ex: déduction suite à une construction), on utilise directement la valeur serveur.
+    // - Sinon (lag de polling normal), on garde la valeur affichée pour éviter les oscillations.
+    const prevServer = prevServerRef.current;
     const prevDisplayed = resources;
-    baseResourcesRef.current = {
-      metal: prevDisplayed ? Math.max(planet.metal_amount, prevDisplayed.metal) : planet.metal_amount,
-      crystal: prevDisplayed ? Math.max(planet.crystal_amount, prevDisplayed.crystal) : planet.crystal_amount,
-      deuterium: prevDisplayed ? Math.max(planet.deuterium_amount, prevDisplayed.deuterium) : planet.deuterium_amount,
+    const serverNow = { metal: planet.metal_amount, crystal: planet.crystal_amount, deuterium: planet.deuterium_amount };
+
+    const resolveBase = (serverVal: number, prevServerVal: number | undefined, displayedVal: number | undefined): number => {
+      // Si la valeur serveur a diminué → déduction → utiliser la valeur serveur
+      if (prevServerVal !== undefined && serverVal < prevServerVal - 1) return serverVal;
+      // Sinon, ne pas reculer en dessous de ce qui est affiché (lag de polling)
+      return displayedVal ? Math.max(serverVal, displayedVal) : serverVal;
     };
-    void prevResources;
+
+    prevServerRef.current = serverNow;
+    baseResourcesRef.current = {
+      metal: resolveBase(serverNow.metal, prevServer?.metal, prevDisplayed?.metal),
+      crystal: resolveBase(serverNow.crystal, prevServer?.crystal, prevDisplayed?.crystal),
+      deuterium: resolveBase(serverNow.deuterium, prevServer?.deuterium, prevDisplayed?.deuterium),
+    };
 
     // Sauvegarder les productions pour le ticker
     const productionRef = { metalProdPerSec, crystalProdPerSec, deutProdPerSec };


### PR DESCRIPTION
- useRealtimeResources: detect server-value decrease (deduction) vs polling lag — skip Math.max only when server value drops, keeping anti-oscillation for normal production ticks. Fixes resources appearing unchanged in top bar after building ships/defenses/research.

- PlanetOverview, Facilities, Shipyard, ResourceDisplay, ExpeditionZone(V2): replace all raw '{tl}s' / '{timeLeft}s' displays with formatDuration() so the construction queue and timers show '11h 45m 23s' instead of '42283s'.

- upgrade_mine_handler: fix building key 'research' → 'research_lab' so the research lab level bonus is correctly applied to research time calculation.

- changelog: add v3.7.0 entry