### PR TITLE
fix(planet-sell): switch to homeworld instead of logging out when sol…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -398,15 +398,15 @@ function AppContent({
           const planets = await myPlanetsRes.json();
           if (Array.isArray(planets) && planets.length > 0) {
             const homeworld = planets.find((p: { is_homeworld: boolean; id: string }) => p.is_homeworld) ?? planets[0];
-            setPlanetId(homeworld.id);
-            localStorage.setItem('planet_id', homeworld.id);
+            switchPlanet(homeworld.id); // updates PlanetContext + localStorage + triggers fetchPlanet
+            setPlanetId(homeworld.id);  // keeps App's own state in sync
           }
         }
       }
     } catch (e) {
         console.error(e);
     }
-  }, [planetId, token, playSound, setPlanetId]);
+  }, [planetId, token, playSound, setPlanetId, switchPlanet]);
 
   // Handle messages when we hear the event emitted by WebSocketContext
   useEffect(() => {

--- a/frontend/src/contexts/PlanetContext.tsx
+++ b/frontend/src/contexts/PlanetContext.tsx
@@ -52,6 +52,23 @@ export function PlanetProvider({ children, initialPlanetId, token }: { children:
       } else {
         console.error("Failed to fetch planet:", await res.text());
         if (res.status === 404) {
+          // Planet no longer exists (sold/conquered) — switch to homeworld
+          try {
+            const myPlanetsRes = await fetch(apiUrl('/my-planets'), {
+              headers: { Authorization: `Bearer ${token}` }
+            });
+            if (myPlanetsRes.ok) {
+              const planets = await myPlanetsRes.json();
+              if (Array.isArray(planets) && planets.length > 0) {
+                const homeworld = planets.find((p: { is_homeworld: boolean }) => p.is_homeworld) ?? planets[0];
+                currentPlanetIdRef.current = homeworld.id;
+                setPlanetId(homeworld.id);
+                localStorage.setItem('planet_id', homeworld.id);
+                return; // useEffect will re-trigger fetchPlanet with new id
+              }
+            }
+          } catch { /* ignore */ }
+          // No planets left — clear state
           localStorage.removeItem('planet_id');
           setPlanetId(null);
           currentPlanetIdRef.current = null;


### PR DESCRIPTION
…d planet returns 404

- PlanetContext.fetchPlanet: on 404, fetch /my-planets and switch to homeworld instead of clearing state — prevents infinite SpaceLoader and logout on refresh
- App.checkMessageAndReports: call switchPlanet() (updates PlanetContext) in addition to setPlanetId() to keep both states in sync