### PR TITLE
fix(combat): correct fuel formula divisor and redesign build time sca…

### DIFF
--- a/backend/src/build_queue.rs
+++ b/backend/src/build_queue.rs
@@ -294,17 +294,21 @@ async fn start_item_immediately(
             let effective_level = current_level + active_in_cq;
             let new_level = target_level.unwrap_or(effective_level + 1);
 
-            // Calculate cost at effective level for build time
-            let _cost_m = tech_tree::calculate_building_cost(building.base_cost_metal, building.cost_multiplier, effective_level);
-            let _cost_c = tech_tree::calculate_building_cost(building.base_cost_crystal, building.cost_multiplier, effective_level);
-
             // Determine facility level for build time formula (shipyard reduces all building times)
             let facility_key = "shipyard";
             let facility_level = tech_tree::get_planet_building_level(db, planet_id, facility_key)
                 .await.unwrap_or(0);
             let nanite_level = tech_tree::get_planet_building_level(db, planet_id, "nanite_factory")
                 .await.unwrap_or(0);
-            let build_time = crate::game_logic::get_build_time_with_nanite(new_level, facility_level, nanite_level, crate::game_logic::building_category_factor(item_key), config);
+            let build_time = crate::game_logic::get_build_time_from_cost(
+                building.base_cost_metal as f64,
+                building.base_cost_crystal as f64,
+                building.cost_multiplier,
+                new_level,
+                facility_level,
+                nanite_level,
+                config,
+            );
             let end_time = now + Duration::seconds(build_time);
 
             let item = construction_queue::ActiveModel {

--- a/backend/src/game_logic.rs
+++ b/backend/src/game_logic.rs
@@ -478,6 +478,7 @@ pub fn get_build_time(level: i32, facility_level: i32, category_factor: f64, con
 
 /// Variante de get_build_time incluant la réduction de la nanite_factory.
 /// nanite_level : chaque niveau divise le temps final par 2 (formule : time / 2^nanite_level).
+/// Conservé pour compatibilité — préférer get_build_time_from_cost quand les coûts sont disponibles.
 pub fn get_build_time_with_nanite(level: i32, facility_level: i32, nanite_level: i32, category_factor: f64, config: &ServerConfigCache) -> i64 {
     const BASE_TIME: f64 = 1800.0;   // 30 min à L1
     const EXPONENT: f64 = 1.40;
@@ -490,6 +491,37 @@ pub fn get_build_time_with_nanite(level: i32, facility_level: i32, nanite_level:
     // nanite_factory : chaque niveau divise le temps par 2
     let nanite_divisor = (2_f64).powi(nanite_level);
     std::cmp::max(1, (raw_time / nanite_divisor) as i64)
+}
+
+/// Temps de construction basé sur le coût réel du bâtiment au niveau cible.
+///
+/// Formule : (metal + crystal) * cost_factor^(target_level-1) / BUILD_RATE * 3600
+///           * (1 - facility_bonus) / building_speed / 2^nanite_level
+///
+/// Garantit un scaling exponentiel en phase avec les coûts réels, contrairement à
+/// la formule polynomiale de get_build_time_with_nanite.
+///
+/// MIN_SECS = 30 — plancher raisonnable pour un serveur 50×.
+pub fn get_build_time_from_cost(
+    base_metal: f64,
+    base_crystal: f64,
+    cost_factor: f64,
+    target_level: i32,
+    facility_level: i32,
+    nanite_level: i32,
+    config: &ServerConfigCache,
+) -> i64 {
+    const BUILD_RATE: f64 = 2500.0;         // ressources/heure (1× univers)
+    const FACILITY_BONUS: f64 = 0.05;       // -5% par niveau de chantier
+    const MAX_FACILITY_BONUS: f64 = 0.50;   // réduction max 50%
+    const MIN_SECS: i64 = 30;               // plancher minimal
+
+    let factor = cost_factor.powi(target_level - 1);
+    let total_cost = (base_metal + base_crystal) * factor;
+    let facility_reduction = (facility_level as f64 * FACILITY_BONUS).min(MAX_FACILITY_BONUS);
+    let raw_secs = (total_cost / BUILD_RATE) * 3600.0 * (1.0 - facility_reduction) / config.building_speed;
+    let nanite_divisor = (2_f64).powi(nanite_level);
+    std::cmp::max(MIN_SECS, (raw_secs / nanite_divisor) as i64)
 }
 
 /// Temps de production d'un vaisseau/défense, basé sur son coût réel.

--- a/backend/src/handlers/fleet.rs
+++ b/backend/src/handlers/fleet.rs
@@ -293,7 +293,7 @@ async fn attack_v2_handler(
         (target_planet.galaxy, target_planet.system, target_planet.position),
     );
 
-    let fuel_needed = (total_fuel_per_unit * dist / 1000.0).ceil().max(1.0);
+    let fuel_needed = (total_fuel_per_unit * dist / 35000.0).ceil().max(1.0);
     if att_planet.deuterium_amount < fuel_needed {
         return (StatusCode::BAD_REQUEST, Json(json!({
             "error": format!("Deutérium insuffisant ({} requis, {} disponible)",
@@ -476,7 +476,7 @@ async fn spy_v2_handler(
         (att_planet.galaxy, att_planet.system, att_planet.position),
         (def_planet.galaxy, def_planet.system, def_planet.position),
     );
-    let spy_fuel_needed = (total_fuel_spy * spy_dist / 1000.0).ceil().max(1.0);
+    let spy_fuel_needed = (total_fuel_spy * spy_dist / 35000.0).ceil().max(1.0);
     if att_planet.deuterium_amount < spy_fuel_needed {
         return (StatusCode::BAD_REQUEST, Json(json!({
             "error": format!("Deutérium insuffisant ({} requis, {} disponible)",
@@ -792,7 +792,7 @@ async fn recycle_handler(
         .map(|s| s.fuel_consumption as f64)
         .unwrap_or(300.0);
 
-    let fuel_needed = (payload.recyclers as f64 * recycler_fuel * dist / 1000.0).ceil().max(1.0);
+    let fuel_needed = (payload.recyclers as f64 * recycler_fuel * dist / 35000.0).ceil().max(1.0);
     if source_planet.deuterium_amount < fuel_needed {
         return (StatusCode::BAD_REQUEST, Json(json!({
             "error": format!("Deutérium insuffisant ({} requis, {} disponible)",
@@ -1455,7 +1455,7 @@ async fn expedition_v2_handler(
         expedition_fuel_per_unit += (count as f64) * (ship.fuel_consumption as f64);
     }
 
-    let expedition_fuel_needed = (expedition_fuel_per_unit * 5000.0 / 1000.0).ceil().max(1.0);
+    let expedition_fuel_needed = (expedition_fuel_per_unit * 5000.0 / 35000.0).ceil().max(1.0);
     if planet.deuterium_amount < expedition_fuel_needed {
         return (StatusCode::BAD_REQUEST, Json(json!({
             "error": format!("Deutérium insuffisant pour l'expédition ({} requis, {} disponible)",
@@ -2672,7 +2672,7 @@ async fn join_acs_handler(
         (target_planet.galaxy, target_planet.system, target_planet.position),
     );
 
-    let fuel_needed = (total_fuel * dist / 1000.0).ceil().max(1.0);
+    let fuel_needed = (total_fuel * dist / 35000.0).ceil().max(1.0);
     if source_planet.deuterium_amount < fuel_needed {
         return (StatusCode::BAD_REQUEST, Json(json!({
             "error": format!("Deutérium insuffisant ({} requis, {} disponible)",
@@ -2896,7 +2896,7 @@ async fn fleet_estimate_handler(
                     count as f64 * fuel as f64
                 })
                 .sum();
-            (total_fuel_per_unit * dist / 1000.0).ceil().max(1.0)
+            (total_fuel_per_unit * dist / 35000.0).ceil().max(1.0)
         }
     } else {
         0.0

--- a/backend/src/handlers/planets.rs
+++ b/backend/src/handlers/planets.rs
@@ -1362,6 +1362,11 @@ async fn upgrade_mine_handler(
     };
     let mut build_time = if is_research {
         game_logic::get_research_time(&type_mine, target_level, facility_level, &config)
+    } else if let Some(entry) = state.building_cost_cache.costs.get(&type_mine as &str) {
+        game_logic::get_build_time_from_cost(
+            entry.base_metal, entry.base_crystal, entry.cost_factor,
+            target_level, facility_level, nanite_level, &config,
+        )
     } else {
         game_logic::get_build_time_with_nanite(target_level, facility_level, nanite_level, game_logic::building_category_factor(&type_mine), &config)
     };
@@ -1520,6 +1525,11 @@ async fn cancel_construction_handler(
         };
         if is_tech {
             game_logic::get_research_time(&item.building_type, item.level, facility_level, &config) as f64
+        } else if let Some(entry) = state.building_cost_cache.costs.get(&item.building_type) {
+            game_logic::get_build_time_from_cost(
+                entry.base_metal, entry.base_crystal, entry.cost_factor,
+                item.level, facility_level, nanite_lvl, &config,
+            ) as f64
         } else {
             game_logic::get_build_time_with_nanite(item.level, facility_level, nanite_lvl, game_logic::building_category_factor(&item.building_type), &config) as f64
         }

--- a/backend/src/tech_tree.rs
+++ b/backend/src/tech_tree.rs
@@ -751,7 +751,15 @@ pub async fn get_building_types_for_planet(
 
         // Calculate next level build time (with nanite_factory reduction)
         let next_level_time = if current_level >= 0 {
-            Some(game_logic::get_build_time_with_nanite(current_level + 1, shipyard_level, nanite_level, game_logic::building_category_factor(&building.building_key), config))
+            Some(game_logic::get_build_time_from_cost(
+                building.base_cost_metal as f64,
+                building.base_cost_crystal as f64,
+                building.cost_multiplier,
+                current_level + 1,
+                shipyard_level,
+                nanite_level,
+                config,
+            ))
         } else {
             None
         };


### PR DESCRIPTION
…ling

Bug 1 — Fuel cost 3.1 B deuterium requis
  The fuel formula used `/1000` as divisor, producing absurdly large costs
  for any significant fleet or distance.  Changed to `/35000` (OGame-standard)
  across all dispatch paths: attack, spy, recycle, expedition, deploy, and the
  fleet estimate endpoint.  Fuel costs are now ~35× lower and scale sensibly.

Bug 2 — Temps de construction trop courts / uniformes
  `get_build_time_with_nanite` used a polynomial `level^1.4` formula that
  produced sub-10 s times at building_speed=50, causing the `max(10, …)`
  floor to mask any difference between levels.

  Added `get_build_time_from_cost(base_metal, base_crystal, cost_factor,
  target_level, facility_level, nanite_level, config)`:
    time = (metal + crystal) × cost_factor^(level-1) / 2500 × 3600
           × (1 − facility_reduction) / building_speed / 2^nanite_level
    minimum = 30 s

  This ties build time directly to actual resource costs, which already
  scale exponentially, so times are proportional to the upgrade investment.

  Updated call-sites: build_queue, tech_tree, planets (upgrade handler and
  cancel-refund handler).  Old function kept as fallback.

https://claude.ai/code/session_01FCqVDrCYbsKWy4D7xzyH61